### PR TITLE
fix: apply IMU extrinsics to orientation in ImuInitialCalibrator

### DIFF
--- a/include/mola_imu_preintegration/ImuInitialCalibrator.h
+++ b/include/mola_imu_preintegration/ImuInitialCalibrator.h
@@ -89,7 +89,9 @@ class ImuInitialCalibrator
    private:
     std::map<std::string /*sensorLabel*/, ImuTransformer> imu_transformers_;
 
-    /// Samples here have been already transformed to be on the base_link frame:
+    /// Samples here have been already transformed to be on the base_link frame
+    /// (accel, gyro AND the absolute-orientation quaternion; placeholder identity
+    /// orientations from non-attitude IMUs are dropped on insertion):
     std::map<double, const mrpt::obs::CObservationIMU> samples_;
 };
 

--- a/src/ImuInitialCalibrator.cpp
+++ b/src/ImuInitialCalibrator.cpp
@@ -31,6 +31,8 @@
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/poses/SO_SE_average.h>
 
+#include <Eigen/Dense>  // required by MRPT matrix transpose()/operator* below
+#include <cmath>
 #include <exception>
 #include <sstream>
 
@@ -42,9 +44,63 @@ void ImuInitialCalibrator::add(const mrpt::obs::CObservationIMU::ConstPtr& obs)
     ASSERT_(parameters.required_samples > 2);
     ASSERT_(parameters.max_samples_age > 0);
 
-    // Add IMU reading, after rotating it so it is body frame-referenced:
-    samples_.emplace(
-        mrpt::Clock::toDouble(obs->timestamp), imu_transformers_[obs->sensorLabel].process(*obs));
+    // Rotate accel/gyro so they are body (base_link) frame-referenced:
+    mrpt::obs::CObservationIMU bodyImu = imu_transformers_[obs->sensorLabel].process(*obs);
+
+    // ImuTransformer only rotates accel/gyro; the absolute-orientation quaternion
+    // (if present) is left in the SENSOR frame. Bring it to the vehicle frame too,
+    // R_world_vehicle = R_world_sensor * R_vehicle_sensor^T, so the orientation-
+    // derived pitch/roll in getCalibration() describe the VEHICLE and not the
+    // (possibly rotated) sensor. Also DROP a PLACEHOLDER identity quaternion: some
+    // IMUs that do NOT estimate attitude (e.g. the Hesai built-in IMU) still ship
+    // a bit-exact identity quaternion tagged orientation_covariance[0]=0, which
+    // the ROS bridge forwards as "valid". It is not a real attitude, and through a
+    // rotated mount it would fabricate a bogus pitch/roll; dropped, the (already
+    // body-frame) accelerometer-gravity path does the leveling instead.
+    if (bodyImu.has(mrpt::obs::IMU_ORI_QUAT_W))
+    {
+        const auto qw = bodyImu.get(mrpt::obs::IMU_ORI_QUAT_W);
+        const auto qx = bodyImu.get(mrpt::obs::IMU_ORI_QUAT_X);
+        const auto qy = bodyImu.get(mrpt::obs::IMU_ORI_QUAT_Y);
+        const auto qz = bodyImu.get(mrpt::obs::IMU_ORI_QUAT_Z);
+
+        const bool isPlaceholderIdentity = std::abs(qx) < 1e-6 && std::abs(qy) < 1e-6 &&
+                                           std::abs(qz) < 1e-6 &&
+                                           std::abs(std::abs(qw) - 1.0) < 1e-6;
+        if (isPlaceholderIdentity)
+        {
+            bodyImu.dataIsPresent.at(mrpt::obs::IMU_ORI_QUAT_W) = false;
+            bodyImu.dataIsPresent.at(mrpt::obs::IMU_ORI_QUAT_X) = false;
+            bodyImu.dataIsPresent.at(mrpt::obs::IMU_ORI_QUAT_Y) = false;
+            bodyImu.dataIsPresent.at(mrpt::obs::IMU_ORI_QUAT_Z) = false;
+        }
+        else
+        {
+            // obs->sensorPose still holds R_vehicle_sensor (process() reset the
+            // sensor pose on the returned COPY only, not on the input obs):
+            const mrpt::math::CMatrixDouble33 R_world_sensor =
+                mrpt::poses::CPose3D::FromQuaternion(mrpt::math::CQuaternionDouble(qw, qx, qy, qz))
+                    .getRotationMatrix();
+            const mrpt::math::CMatrixDouble33 R_vehicle_sensor =
+                obs->sensorPose.getRotationMatrix();
+
+            mrpt::math::CMatrixDouble33 R_world_vehicle;
+            R_world_vehicle.asEigen() =
+                R_world_sensor.asEigen() * R_vehicle_sensor.asEigen().transpose();
+
+            mrpt::poses::CPose3D pv;
+            pv.setRotationMatrix(R_world_vehicle);
+            mrpt::math::CQuaternionDouble qv;
+            pv.getAsQuaternion(qv);
+            bodyImu.set(mrpt::obs::IMU_ORI_QUAT_W, qv.w());
+            bodyImu.set(mrpt::obs::IMU_ORI_QUAT_X, qv.x());
+            bodyImu.set(mrpt::obs::IMU_ORI_QUAT_Y, qv.y());
+            bodyImu.set(mrpt::obs::IMU_ORI_QUAT_Z, qv.z());
+        }
+    }
+
+    // Add IMU reading (now fully body frame-referenced, orientation included):
+    samples_.emplace(mrpt::Clock::toDouble(obs->timestamp), std::move(bodyImu));
 
     // Remove old samples:
     while (!samples_.empty() &&

--- a/tests/test-imu-initial-calibrator.cpp
+++ b/tests/test-imu-initial-calibrator.cpp
@@ -26,6 +26,7 @@
 #include <mrpt/math/CQuaternion.h>
 #include <mrpt/math/TPoint3D.h>
 #include <mrpt/obs/CObservationIMU.h>
+#include <mrpt/poses/CPose3D.h>
 
 #include <cmath>
 #include <iostream>
@@ -106,10 +107,12 @@ inline void assert_near_impl(
 // Helper function to create an IMU observation
 mrpt::obs::CObservationIMU::Ptr create_imu_obs(
     double time_sec, const mrpt::math::TVector3D& acc, const mrpt::math::TVector3D& gyro,
-    const std::optional<mrpt::math::CQuaternionDouble>& orientation_quat = std::nullopt)
+    const std::optional<mrpt::math::CQuaternionDouble>& orientation_quat = std::nullopt,
+    const mrpt::poses::CPose3D& sensorPose = mrpt::poses::CPose3D::Identity())
 {
-    auto obs       = mrpt::obs::CObservationIMU::Create();
-    obs->timestamp = mrpt::Clock::fromDouble(time_sec);
+    auto obs        = mrpt::obs::CObservationIMU::Create();
+    obs->timestamp  = mrpt::Clock::fromDouble(time_sec);
+    obs->sensorPose = sensorPose;
 
     // Accelerations (IMU_X_ACC, IMU_Y_ACC, IMU_Z_ACC)
     obs->set(mrpt::obs::IMU_X_ACC, acc.x);
@@ -581,6 +584,87 @@ void TestImuInitialCalibrator()
         // std::cout << calib->asString();
 
         std::cout << "Test 9: 60 deg roll (gravity-based attitude) OK.\n";
+    }
+
+    // A genuinely tilted vehicle (pitch +20, roll -12) with the IMU mounted
+    // rotated ~90 deg wrt base_link (the Hesai "_90deg" case). In both sub-tests
+    // the recovered attitude must be the VEHICLE's, proving the sensor->vehicle
+    // extrinsics are applied to BOTH the accelerometer and the orientation
+    // quaternion.
+    const double tiltPitch  = mrpt::DEG2RAD(20.0);
+    const double tiltRoll   = mrpt::DEG2RAD(-12.0);
+    const auto   vehicleAtt = mrpt::poses::CPose3D::FromYawPitchRoll(0.0, tiltPitch, tiltRoll);
+    // Hesai-style mount: 90 deg yaw then 90 deg roll, plus a lever arm:
+    const auto mount = mrpt::poses::CPose3D::FromXYZYawPitchRoll(
+        0.1, -0.2, 0.3, mrpt::DEG2RAD(90.0), 0.0, mrpt::DEG2RAD(90.0));
+
+    // 10. Rotated mount + PLACEHOLDER identity orientation (what the Hesai IMU
+    //     ships). The identity quaternion is NOT a real attitude; it must be
+    //     dropped so the (mount-corrected) gravity recovers the vehicle tilt,
+    //     instead of fabricating a level (0,0) attitude.
+    {
+        ImuInitialCalibrator calibrator;  // use_imu_orientation defaults to true
+        calibrator.parameters.required_samples = 3;
+        calibrator.parameters.max_samples_age  = 100.0;
+        const double g                         = calibrator.parameters.gravity;
+
+        // Specific force the accelerometer reads, in the SENSOR frame:
+        const auto a_body   = vehicleAtt.inverseRotateVector({0.0, 0.0, g});
+        const auto a_sensor = mount.inverseRotateVector(a_body);
+
+        const mrpt::math::CQuaternionDouble placeholder(1.0, 0.0, 0.0, 0.0);  // identity
+
+        for (int i = 0; i < 5; ++i)
+        {
+            calibrator.add(create_imu_obs(
+                90.0 + static_cast<double>(i), a_sensor, {0.0, 0.0, 0.0}, placeholder, mount));
+        }
+
+        auto calib = calibrator.getCalibration();
+        ASSERT_(calib.has_value());
+
+        const double tol = 1e-5;
+        MRPT_ASSERT_NEAR_MSG_(
+            calib->pitch, tiltPitch, tol, "pitch (rotated mount, placeholder orientation)");
+        MRPT_ASSERT_NEAR_MSG_(
+            calib->roll, tiltRoll, tol, "roll (rotated mount, placeholder orientation)");
+
+        std::cout << "Test 10: rotated mount + placeholder identity orientation OK.\n";
+    }
+
+    // 11. Rotated mount + TRUE world-attitude quaternion. The orientation must be
+    //     brought to the vehicle frame (R_world_vehicle = R_world_sensor *
+    //     R_vehicle_sensor^T), recovering the VEHICLE tilt and NOT the rotated
+    //     sensor's ~90 deg attitude.
+    {
+        ImuInitialCalibrator calibrator;
+        calibrator.parameters.required_samples = 3;
+        calibrator.parameters.max_samples_age  = 100.0;
+        const double g                         = calibrator.parameters.gravity;
+
+        const auto a_body   = vehicleAtt.inverseRotateVector({0.0, 0.0, g});
+        const auto a_sensor = mount.inverseRotateVector(a_body);
+
+        // True sensor world attitude: R_world_sensor = R_world_vehicle * R_vehicle_sensor.
+        mrpt::math::CQuaternionDouble qWorldSensor;
+        (vehicleAtt + mount).getAsQuaternion(qWorldSensor);
+
+        for (int i = 0; i < 5; ++i)
+        {
+            calibrator.add(create_imu_obs(
+                110.0 + static_cast<double>(i), a_sensor, {0.0, 0.0, 0.0}, qWorldSensor, mount));
+        }
+
+        auto calib = calibrator.getCalibration();
+        ASSERT_(calib.has_value());
+
+        const double tol = 1e-5;
+        MRPT_ASSERT_NEAR_MSG_(
+            calib->pitch, tiltPitch, tol, "pitch (rotated mount, true world orientation)");
+        MRPT_ASSERT_NEAR_MSG_(
+            calib->roll, tiltRoll, tol, "roll (rotated mount, true world orientation)");
+
+        std::cout << "Test 11: rotated mount + true world orientation OK.\n";
     }
 
     std::cout << "--- TestImuInitialCalibrator finished OK ---\n";


### PR DESCRIPTION
## Problem

`ImuInitialCalibrator` (used by MOLA-LO's `InitLocalization::PitchAndRollFromIMU`) had two sensor-extrinsics bugs, both exposed by an IMU mounted rotated wrt `base_link` (e.g. the Hesai built-in IMU, which is rotated ~90 deg — `floor` ends up looking like a `wall`):

1. **Orientation quaternion never transformed to the vehicle frame.** `add()` runs samples through `ImuTransformer`, which rotates accel/gyro only; the absolute-orientation quaternion was left in the *sensor* frame (the header even claimed samples were "already on the base_link frame"). With `use_imu_orientation=true` (default), `getCalibration()` returned the **rotated sensor's** pitch/roll instead of the vehicle's.
2. **Placeholder identity orientation trusted.** Some IMUs that do not estimate attitude still ship a bit-exact identity quaternion tagged `orientation_covariance[0]=0`, which the ROS bridge forwards as "valid". On a rotated mount this fabricates a bogus attitude and masks the real vehicle tilt.

## Fix

`add()` now:
- brings the orientation to the vehicle frame: `R_world_vehicle = R_world_sensor * R_vehicle_sensor^T` (using the original `obs->sensorPose`, before `process()` resets it on the returned copy);
- drops a placeholder identity quaternion so the (already mount-corrected) accelerometer gravity provides the leveling instead.

Header comment updated to reflect that the stored samples are now fully body-frame referenced, orientation included.

## Tests

Extended the obs helper with a `sensorPose` and added two regression cases on a genuinely tilted vehicle (pitch +20°, roll −12°) with a Hesai-style 90° mount:
- **Test 10** — rotated mount + placeholder identity → must recover the vehicle tilt from gravity.
- **Test 11** — rotated mount + true world orientation → must recover the vehicle tilt after transforming to the vehicle frame.

Both verified to **fail on the pre-fix code** (Test 10 reported pitch `−0` instead of 20°) and pass after. Full suites green: `mola_imu_preintegration` 10/10, `mola_lidar_odometry` 24/24, `mola_mapper_3d` 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMU initial calibration when the sensor is mounted at an angle or with a lever arm.
  * Orientation data is now handled more robustly, including ignoring placeholder identity quaternions so gravity-based leveling works correctly.

* **Tests**
  * Expanded calibration tests to cover rotated IMU mounting and orientation-based initialization scenarios.
  * Fixed IMU test sample creation so sensor pose is properly included in generated observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->