### PR TITLE
fix: return empty trajectory instead of throwing on insufficient IMU data

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -31,7 +31,9 @@ visual-inertial preintegrator** (no ΔV/ΔP, no covariance, no bias Jacobians ye
 - Quaternion YAML order is `[x,y,z,w]` (ROS/REP-103).
 - `cov_gyro`/`cov_acc` params exist but are **not yet consumed** by any algorithm.
 - `trajectory_from_buffer` uses the sample closest to the **latest** timestamp as the anchor and
-  integrates forward+backward; it assumes at least one orientation and one velocity sample exist.
+  integrates forward+backward; if the buffer lacks the minimum anchors (one orientation, one
+  velocity, one gyro and one accel sample) it returns an **empty trajectory** instead of throwing,
+  so callers skip integration for that scan.
 
 ## Build & test
 Standard MOLA/colcon build (see root MOLA repo). Tests are plain executables that return non-zero
@@ -42,6 +44,5 @@ clang-format-14 (`scripts/formatter.sh`); American spelling; no one-line `if`; o
 declaration; anonymous namespaces over `static`; avoid em dashes.
 
 ## Active improvement plan
-See `~/plans/800_imu.md` for the in-progress review (math gaps, latent crash in
-`trajectory_from_buffer` on empty IMU input, missing `ImuTransformer` tests, covariance/Jacobian
-TODOs). Keep that doc's checkboxes updated as work lands.
+See `~/plans/800_imu.md` for the in-progress review (math gaps, missing `ImuTransformer` tests,
+covariance/Jacobian TODOs). Keep that doc's checkboxes updated as work lands.

--- a/include/mola_imu_preintegration/trajectory_from_buffer.h
+++ b/include/mola_imu_preintegration/trajectory_from_buffer.h
@@ -86,10 +86,17 @@ std::string trajectory_as_string(const Trajectory& traj);
  * it consists of integrating the IMU data using as anchor at least one global gravity-aligned
  * orientation and one linear velocity.
  *
+ * If the buffer lacks the minimum anchors required to integrate (at least one
+ * angular velocity, one linear acceleration, one gravity-aligned orientation and
+ * one linear velocity sample), an empty trajectory is returned. This is an
+ * expected runtime condition (e.g. sensor warm-up or a transient data gap), so
+ * callers should check for an empty result and skip integration accordingly.
+ *
  * @param samples IMU and other LIO data samples
  * @param imu_params IMU integration parameters, in particular, biases
  * @param use_higher_order Whether to use higher-order integration (jerk)
- * @return Trajectory With the reconstructed trajectory
+ * @return The reconstructed trajectory, or an empty trajectory if the input
+ *         buffer lacks the minimum anchors listed above.
  */
 Trajectory trajectory_from_buffer(
     const LocalVelocityBuffer::SampleHistory& samples, const ImuIntegrationParams& imu_params,

--- a/src/trajectory_from_buffer.cpp
+++ b/src/trajectory_from_buffer.cpp
@@ -142,33 +142,40 @@ Trajectory mola::imu::trajectory_from_buffer(
         }
     }
 
-    // and assign the closest IMU reading to t=0:
+    // and assign the closest IMU reading to t=0.
+    // Insufficient sensor data (e.g. during sensor warm-up or a transient data
+    // gap) is an expected runtime condition, not a programming error: return an
+    // empty trajectory so callers can gracefully skip integration for this scan.
     const auto closest_w_at_0 = mrpt::containers::find_closest(samples.by_type.w_b, 0.0);
     const auto closest_a_at_0 = mrpt::containers::find_closest(samples.by_type.a_b, 0.0);
-    ASSERTMSG_(
-        closest_w_at_0, "At least one entry with angular velocity is needed for IMU integration");
-    ASSERTMSG_(
-        closest_a_at_0,
-        "At least one entry with linear acceleration is needed for IMU integration");
+    if (!closest_w_at_0 || !closest_a_at_0)
+    {
+        return {};
+    }
     t[0].w_b = closest_w_at_0->second - bias_gyro;
     t[0].a_b = closest_a_at_0->second - bias_acc;
 
     // 3) Copy the latest gravity-aligned hints on global orientations:
-    ASSERTMSG_(
-        !samples.by_time.empty(),
-        "At least one IMU sample with timestamp is needed for IMU integration");
+    if (samples.by_time.empty())
+    {
+        return {};
+    }
     const double last_sample_rel_time = samples.by_time.rbegin()->first;
     const auto closest_q = mrpt::containers::find_closest(samples.by_type.q, last_sample_rel_time);
-    ASSERTMSG_(
-        closest_q,
-        "At least one entry with gravity-aligned orientation is needed for IMU integration");
+    if (!closest_q)
+    {
+        return {};
+    }
     const double stamp_first_R_ga = closest_q->first;
     t[closest_q->first].R_ga      = closest_q->second;
 
     // 3b) and copy the closest velocity from the given samples:
     const auto closest_v_b =
         mrpt::containers::find_closest(samples.by_type.v_b, last_sample_rel_time);
-    ASSERTMSG_(closest_v_b, "At least one entry with velocity is needed for IMU integration");
+    if (!closest_v_b)
+    {
+        return {};
+    }
     const double stamp_first_v_b = closest_v_b->first;
     t[closest_v_b->first].v      = closest_v_b->second;
 

--- a/tests/test-trajectory-from-buffer.cpp
+++ b/tests/test-trajectory-from-buffer.cpp
@@ -361,6 +361,44 @@ void TrajectoryFromBuffer_Spinning3D()
     MRPT_END
 }
 
+// Test Case 6: Insufficient data is gracefully reported as an empty trajectory,
+// rather than throwing, so callers can skip integration for this scan.
+void TrajectoryFromBuffer_InsufficientData()
+{
+    MRPT_START
+
+    ImuIntegrationParams imu_params;
+    imu_params.gravity_vector = {0, 0, -9.81};
+
+    // Empty buffer: no anchors at all.
+    {
+        LocalVelocityBuffer buffer;
+        buffer.set_reference_zero_time(0.0);
+        auto       samples            = buffer.collect_samples_around_reference_time(10.0);
+        Trajectory reconstructed_traj = trajectory_from_buffer(samples, imu_params, false);
+        ASSERT_(reconstructed_traj.empty());
+    }
+
+    // Buffer with gyro+accel but no gravity-aligned orientation nor velocity:
+    {
+        LocalVelocityBuffer buffer;
+        buffer.set_reference_zero_time(0.0);
+        buffer.parameters.max_time_window = 20.0;
+        for (double time = 0.0; time <= 1.0; time += IMU_DT)
+        {
+            buffer.add_angular_velocity(time, {0, 0, 0});
+            buffer.add_linear_acceleration(time, {0, 0, 9.81});
+        }
+        auto       samples            = buffer.collect_samples_around_reference_time(10.0);
+        Trajectory reconstructed_traj = trajectory_from_buffer(samples, imu_params, false);
+        ASSERT_(reconstructed_traj.empty());
+    }
+
+    std::cout << "✅ TrajectoryFromBuffer_InsufficientData passed!" << std::endl;
+
+    MRPT_END
+}
+
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
     try
@@ -370,6 +408,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         TrajectoryFromBuffer_PerfectCircle();
         TrajectoryFromBuffer_ConstantLinearVelocityWithRoll();
         TrajectoryFromBuffer_Spinning3D();
+        TrajectoryFromBuffer_InsufficientData();
         return 0;
     }
     catch (const std::exception& e)


### PR DESCRIPTION
## Summary

`trajectory_from_buffer()` asserted (and threw) when the sample buffer lacked a minimum anchor required to integrate: angular velocity, linear acceleration, gravity-aligned orientation, or velocity. These are **expected runtime conditions** during sensor warm-up or transient data gaps, not programming errors. The throw propagated up through callers (e.g. lidar odometry via `FilterDeskew`), crashing the node with:

```
At least one entry with gravity-aligned orientation is needed for IMU integration
```

## Change

Return an **empty trajectory** in these cases instead of throwing. This matches the sentinel callers already use to gracefully skip integration for the affected scan (`reconstructed_trajectory.empty()`).

- Documented as a contract in the header and `agents.md`.
- New `TrajectoryFromBuffer_InsufficientData` unit test covers the empty-buffer and missing-orientation/velocity cases.
- No API/signature change; existing callers and tests are unaffected.

## Companion PR

mp2p_icp adds defense-in-depth so the deskew filter never crashes even on other unexpected exceptions: MOLAorg/mp2p_icp#filterdeskew-graceful-imu-anchor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trajectory reconstruction to safely return an empty result when required sensor inputs are missing, instead of failing unexpectedly.
  * Callers are now expected to skip integration when no valid trajectory can be built.

* **Tests**
  * Added coverage for empty and partially populated input buffers to confirm the new empty-result behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->