### PR TITLE
fix: guard against near-zero dt in ImuTransformer angular-accel finite difference

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -34,6 +34,10 @@ visual-inertial preintegrator** (no ΔV/ΔP, no covariance, no bias Jacobians ye
   integrates forward+backward; if the buffer lacks the minimum anchors (one orientation, one
   velocity, one gyro and one accel sample) it returns an **empty trajectory** instead of throwing,
   so callers skip integration for that scan.
+- `ImuTransformer::process()` clamps `dt` to a default rate whenever it falls at or below
+  `MIN_SANE_DT` (1 ms), not just when `<= 0`. Some IMU drivers emit near-duplicate timestamps
+  (microseconds apart); dividing the finite-difference angular acceleration by such a near-zero
+  `dt` amplifies a negligible angular-velocity delta into a huge spurious lever-arm spike.
 
 ## Build & test
 Standard MOLA/colcon build (see root MOLA repo). Tests are plain executables that return non-zero

--- a/src/ImuTransformer.cpp
+++ b/src/ImuTransformer.cpp
@@ -58,10 +58,18 @@ mrpt::obs::CObservationIMU ImuTransformer::process(const mrpt::obs::CObservation
         // amplified gyro noise that finite differencing introduces.
         const auto this_stamp = mrpt::Clock::toDouble(raw_imu.timestamp);
         double     dt         = this_stamp - last_stamp_;
-        if (dt <= 0 || dt > 1.0)
+
+        // Minimum sane dt: some IMU drivers emit near-duplicate timestamps
+        // (e.g. a pair of messages a few microseconds apart). Dividing by
+        // such a tiny dt amplifies an otherwise negligible angular-velocity
+        // difference into a huge spurious angular-acceleration spike, which
+        // then corrupts the lever-arm-corrected acceleration output.
+        constexpr double MIN_SANE_DT = 1e-3;
+
+        if (dt <= MIN_SANE_DT || dt > 1.0)
         {
-            // It's either the first reading, an error, or data flow stopped and resumed.
-            // Then use default rate:
+            // It's either the first reading, a near-duplicate timestamp, an
+            // error, or data flow stopped and resumed. Then use default rate:
             dt = 1.0 / 100.0;
         }
 

--- a/tests/test-imu-transformer.cpp
+++ b/tests/test-imu-transformer.cpp
@@ -212,8 +212,7 @@ void test_near_duplicate_timestamp_no_spike()
     tf.process(*make_imu(100.0, acc, {0.0, 0.0, 0.0}, sensorPose));
     // A microsecond-scale gap with a tiny gyro change, as seen from near-duplicate
     // driver messages:
-    const auto out =
-        tf.process(*make_imu(100.0 + 5e-6, acc, {0.0, 0.0, 0.005}, sensorPose));
+    const auto out  = tf.process(*make_imu(100.0 + 5e-6, acc, {0.0, 0.0, 0.005}, sensorPose));
     const auto aout = get_acc(out);
 
     ASSERT_(std::isfinite(aout.x) && std::isfinite(aout.y) && std::isfinite(aout.z));

--- a/tests/test-imu-transformer.cpp
+++ b/tests/test-imu-transformer.cpp
@@ -199,6 +199,29 @@ void test_dt_fallback()
     std::cout << "✅ test_dt_fallback passed!" << std::endl;
 }
 
+// 6) Near-duplicate timestamps (a few microseconds apart, as emitted by some
+//    IMU drivers) must not amplify a tiny angular-velocity difference into a
+//    huge spurious lever-arm spike via division by a near-zero dt.
+void test_near_duplicate_timestamp_no_spike()
+{
+    const auto sensorPose = mrpt::poses::CPose3D::FromTranslation(0.5, 0.0, 0.0);
+
+    ImuTransformer  tf;
+    const TVector3D acc = {0.0, 0.0, 9.81};
+
+    tf.process(*make_imu(100.0, acc, {0.0, 0.0, 0.0}, sensorPose));
+    // A microsecond-scale gap with a tiny gyro change, as seen from near-duplicate
+    // driver messages:
+    const auto out =
+        tf.process(*make_imu(100.0 + 5e-6, acc, {0.0, 0.0, 0.005}, sensorPose));
+    const auto aout = get_acc(out);
+
+    ASSERT_(std::isfinite(aout.x) && std::isfinite(aout.y) && std::isfinite(aout.z));
+    check_near(aout, acc, 0.5, "near-duplicate-timestamp accel (no spike)");
+
+    std::cout << "✅ test_near_duplicate_timestamp_no_spike passed!" << std::endl;
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -210,6 +233,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_tangential_lever_arm();
         test_first_sample_no_spike();
         test_dt_fallback();
+        test_near_duplicate_timestamp_no_spike();
         std::cout << "All ImuTransformer tests passed." << std::endl;
         return 0;
     }


### PR DESCRIPTION
## Summary
- Some IMU drivers (e.g. the Hesai built-in IMU) emit consecutive messages with near-duplicate timestamps a few microseconds apart. The finite-difference angular-acceleration term in `ImuTransformer::process()` only guarded against `dt <= 0`, so these tiny-but-positive gaps divided a negligible angular-velocity delta into a huge spurious lever-arm correction spike, corrupting the transformed acceleration for that sample.
- Reproduced end-to-end against a real Hesai bag: `ImuInitialCalibrator`'s pitch/roll came out ~33 deg off on a mount where the true tilt (per the bag's own static transforms) is ~2 deg, with roughly a third of IMU samples in the calibration window affected.
- Widens the existing fallback-rate guard to treat any `dt` at or below 1 ms the same as the `dt<=0` case.

## Test plan
- [x] New regression test `test_near_duplicate_timestamp_no_spike` added to `tests/test-imu-transformer.cpp`; confirmed it fails without the fix and passes with it.
- [x] Full package test suite (`colcon test --packages-select mola_imu_preintegration`): 10/10 passing.
- [x] Re-ran the real Hesai bag end-to-end: pitch/roll now -2.30/0.86 deg (was 32.9/~10-15 deg), matching the bag's own static-transform tilt.