### PR TITLE
fix: drop all-zero orientation quaternions in ImuInitialCalibrator

### DIFF
--- a/src/ImuInitialCalibrator.cpp
+++ b/src/ImuInitialCalibrator.cpp
@@ -73,9 +73,13 @@ void ImuInitialCalibrator::add(const mrpt::obs::CObservationIMU::ConstPtr& obs)
         // zeros instead of a placeholder identity. That is not a rotation
         // (norm 0), and would otherwise abort below when handed to
         // CQuaternion; drop it the same way as a placeholder identity.
+        // The comparison is negated (rather than "> 0.1") so a NaN qNormSq
+        // (e.g. from a sensor anomaly) is also classified as degenerate:
+        // NaN fails every relational comparison, so "> 0.1" alone would let
+        // it slip through as if it were a valid unit quaternion.
         const double qNormSq =
             mrpt::square(qw) + mrpt::square(qx) + mrpt::square(qy) + mrpt::square(qz);
-        const bool isDegenerate = std::abs(qNormSq - 1.0) > 0.1;
+        const bool isDegenerate = !(std::abs(qNormSq - 1.0) <= 0.1);
 
         if (isPlaceholderIdentity || isDegenerate)
         {

--- a/src/ImuInitialCalibrator.cpp
+++ b/src/ImuInitialCalibrator.cpp
@@ -67,7 +67,17 @@ void ImuInitialCalibrator::add(const mrpt::obs::CObservationIMU::ConstPtr& obs)
         const bool isPlaceholderIdentity = std::abs(qx) < 1e-6 && std::abs(qy) < 1e-6 &&
                                            std::abs(qz) < 1e-6 &&
                                            std::abs(std::abs(qw) - 1.0) < 1e-6;
-        if (isPlaceholderIdentity)
+
+        // Some drivers that do not estimate attitude at all (e.g. a raw MEMS
+        // IMU with no onboard AHRS) leave the orientation quaternion at all
+        // zeros instead of a placeholder identity. That is not a rotation
+        // (norm 0), and would otherwise abort below when handed to
+        // CQuaternion; drop it the same way as a placeholder identity.
+        const double qNormSq =
+            mrpt::square(qw) + mrpt::square(qx) + mrpt::square(qy) + mrpt::square(qz);
+        const bool isDegenerate = std::abs(qNormSq - 1.0) > 0.1;
+
+        if (isPlaceholderIdentity || isDegenerate)
         {
             bodyImu.dataIsPresent.at(mrpt::obs::IMU_ORI_QUAT_W) = false;
             bodyImu.dataIsPresent.at(mrpt::obs::IMU_ORI_QUAT_X) = false;

--- a/tests/test-imu-initial-calibrator.cpp
+++ b/tests/test-imu-initial-calibrator.cpp
@@ -667,6 +667,47 @@ void TestImuInitialCalibrator()
         std::cout << "Test 11: rotated mount + true world orientation OK.\n";
     }
 
+    // 12. Rotated mount + ALL-ZERO quaternion, as shipped by drivers (e.g. a
+    //     raw MEMS IMU with no onboard AHRS) that leave the orientation field
+    //     unset instead of a placeholder identity. mrpt::math::CQuaternion
+    //     itself refuses to hold a non-normalized (0,0,0,0) value, so the
+    //     zero components are poked in directly, bypassing that type. This
+    //     must be dropped exactly like a placeholder identity, not crash.
+    {
+        ImuInitialCalibrator calibrator;
+        calibrator.parameters.required_samples = 3;
+        calibrator.parameters.max_samples_age  = 100.0;
+        const double g                         = calibrator.parameters.gravity;
+
+        const auto a_body   = vehicleAtt.inverseRotateVector({0.0, 0.0, g});
+        const auto a_sensor = mount.inverseRotateVector(a_body);
+
+        for (int i = 0; i < 5; ++i)
+        {
+            auto obs = create_imu_obs(
+                120.0 + static_cast<double>(i), a_sensor, {0.0, 0.0, 0.0}, std::nullopt, mount);
+            // Manually inject an all-zero quaternion (dataIsPresent=true),
+            // which create_imu_obs() cannot do via CQuaternionDouble:
+            obs->set(mrpt::obs::IMU_ORI_QUAT_W, 0.0);
+            obs->set(mrpt::obs::IMU_ORI_QUAT_X, 0.0);
+            obs->set(mrpt::obs::IMU_ORI_QUAT_Y, 0.0);
+            obs->set(mrpt::obs::IMU_ORI_QUAT_Z, 0.0);
+
+            calibrator.add(obs);
+        }
+
+        auto calib = calibrator.getCalibration();
+        ASSERT_(calib.has_value());
+
+        const double tol = 1e-5;
+        MRPT_ASSERT_NEAR_MSG_(
+            calib->pitch, tiltPitch, tol, "pitch (rotated mount, all-zero orientation)");
+        MRPT_ASSERT_NEAR_MSG_(
+            calib->roll, tiltRoll, tol, "roll (rotated mount, all-zero orientation)");
+
+        std::cout << "Test 12: rotated mount + all-zero orientation OK.\n";
+    }
+
     std::cout << "--- TestImuInitialCalibrator finished OK ---\n";
 }
 

--- a/tests/test-imu-initial-calibrator.cpp
+++ b/tests/test-imu-initial-calibrator.cpp
@@ -30,6 +30,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -706,6 +707,46 @@ void TestImuInitialCalibrator()
             calib->roll, tiltRoll, tol, "roll (rotated mount, all-zero orientation)");
 
         std::cout << "Test 12: rotated mount + all-zero orientation OK.\n";
+    }
+
+    // 13. Rotated mount + NaN quaternion (e.g. a sensor anomaly). NaN fails
+    //     every relational comparison, so a naive "> 0.1" degenerate check
+    //     would let it slip through as if it were a valid unit quaternion;
+    //     it must be dropped exactly like a placeholder identity, not crash.
+    {
+        ImuInitialCalibrator calibrator;
+        calibrator.parameters.required_samples = 3;
+        calibrator.parameters.max_samples_age  = 100.0;
+        const double g                         = calibrator.parameters.gravity;
+
+        const auto a_body   = vehicleAtt.inverseRotateVector({0.0, 0.0, g});
+        const auto a_sensor = mount.inverseRotateVector(a_body);
+
+        const double nan = std::numeric_limits<double>::quiet_NaN();
+
+        for (int i = 0; i < 5; ++i)
+        {
+            auto obs = create_imu_obs(
+                130.0 + static_cast<double>(i), a_sensor, {0.0, 0.0, 0.0}, std::nullopt, mount);
+            // Manually inject a NaN quaternion (dataIsPresent=true), which
+            // create_imu_obs() cannot do via CQuaternionDouble:
+            obs->set(mrpt::obs::IMU_ORI_QUAT_W, nan);
+            obs->set(mrpt::obs::IMU_ORI_QUAT_X, nan);
+            obs->set(mrpt::obs::IMU_ORI_QUAT_Y, nan);
+            obs->set(mrpt::obs::IMU_ORI_QUAT_Z, nan);
+
+            calibrator.add(obs);
+        }
+
+        auto calib = calibrator.getCalibration();
+        ASSERT_(calib.has_value());
+
+        const double tol = 1e-5;
+        MRPT_ASSERT_NEAR_MSG_(
+            calib->pitch, tiltPitch, tol, "pitch (rotated mount, NaN orientation)");
+        MRPT_ASSERT_NEAR_MSG_(calib->roll, tiltRoll, tol, "roll (rotated mount, NaN orientation)");
+
+        std::cout << "Test 13: rotated mount + NaN orientation OK.\n";
     }
 
     std::cout << "--- TestImuInitialCalibrator finished OK ---\n";


### PR DESCRIPTION
## Summary
- Some IMU drivers (e.g. a raw MEMS IMU with no onboard AHRS, seen on the Oxford Spires dataset's Alphasense IMU) leave `orientation` at an all-zero quaternion instead of a placeholder identity.
- `ImuInitialCalibrator::add()` only dropped the placeholder-identity case; an all-zero quaternion reached `mrpt::math::CQuaternion`'s constructor as-is and aborted with `quaternion is not normalized`.
- Extends the existing drop logic to reject any non-unit-norm quaternion (same tolerance already used in `getCalibration()`), falling back to the already-implemented gravity-based accelerometer leveling.

## Test plan
- [x] `colcon test --packages-select mola_imu_preintegration` — all 10 existing tests + new Test 12 (all-zero quaternion, rotated mount) pass
- [x] Reproduced against a real bag (Oxford Spires dataset) via `mola_lidar_odometry`: crash gone, pitch/roll now correctly derived from the accelerometer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMU calibration handling for missing, placeholder, or invalid orientation data.
  * Prevented degenerate quaternions from affecting calibration results.
  * Ensured calibration continues successfully when orientation data is all zeros.

* **Tests**
  * Added coverage validating accurate pitch and roll recovery with invalid IMU orientation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->