### PR TITLE
Add full on-manifold IMU preintegration and gravity-in-map estimation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,20 +25,26 @@ find_package(mrpt-obs)
 # -----------------------
 # define lib:
 set(LIB_SRCS
+  src/MapGravityEstimator.cpp
   src/ImuInitialCalibrator.cpp
   src/ImuIntegrationParams.cpp
   src/ImuIntegrator.cpp
+  src/ImuPreintegrator.cpp
   src/ImuTransformer.cpp
   src/LocalVelocityBuffer.cpp
   src/register.cpp
+  src/so3_jacobians.cpp
   src/trajectory_from_buffer.cpp
 )
 set(LIB_PUBLIC_HDRS
+  include/mola_imu_preintegration/MapGravityEstimator.h
   include/mola_imu_preintegration/ImuInitialCalibrator.h
   include/mola_imu_preintegration/ImuIntegrationParams.h
   include/mola_imu_preintegration/ImuIntegrator.h
+  include/mola_imu_preintegration/ImuPreintegrator.h
   include/mola_imu_preintegration/ImuTransformer.h
   include/mola_imu_preintegration/LocalVelocityBuffer.h
+  include/mola_imu_preintegration/so3_jacobians.h
   include/mola_imu_preintegration/trajectory_from_buffer.h
 )
 

--- a/agents.md
+++ b/agents.md
@@ -79,10 +79,14 @@ Load-bearing details, do not "simplify" them away:
 - Rejecting an interval is always safe here (the unknowns are global, so
   nothing is left unconstrained), unlike a full-state formulation which needs
   fallback priors.
-- `ImuIntegrationParams` defaults `cov_gyro`/`cov_acc` to IDENTITY, i.e.
-  sigma=1, ~1000x worse than any real MEMS IMU. Always set real noise
-  densities, or every "earned" sigma comes out enormous and the estimator
-  never reports convergence.
+- `ImuIntegrationParams::cov_gyro`/`cov_acc` are continuous-time noise
+  DENSITIES (not per-sample covariances); consumers scale them by the sample
+  period. They default to `DEFAULT_GYRO_NOISE_DENSITY` / `DEFAULT_ACCEL_NOISE_DENSITY`
+  (1.7e-4 rad/s/sqrt(Hz), 2.0e-3 m/s^2/sqrt(Hz)), an industrial-grade MEMS
+  datasheet figure. They used to default to IDENTITY (sigma=1, ~1000x worse
+  than any real sensor), which made every "earned" sigma enormous and stopped
+  the estimator from ever reporting convergence. Field deployments commonly
+  inflate the datasheet density several-fold to absorb vibration.
 
 See `~/plans/801_lio_imu_preintegration_gravity.md` for the design and status.
 

--- a/agents.md
+++ b/agents.md
@@ -39,6 +39,53 @@ visual-inertial preintegrator** (no ΔV/ΔP, no covariance, no bias Jacobians ye
   (microseconds apart); dividing the finite-difference angular acceleration by such a near-zero
   `dt` amplifies a negligible angular-velocity delta into a huge spurious lever-arm spike.
 
+## Full on-manifold preintegration + gravity-in-map estimation (2026-07)
+
+Three additions, all GTSAM-free (MRPT Lie algebra only):
+
+- `so3_jacobians.h` -- SO(3) right Jacobian `Jr` and its inverse, closed form
+  with Taylor branches below 1e-4 rad. NOTE: `Jr` is NOT
+  `mrpt::poses::Lie::SO<3>::jacob_dexpe_de()`, which returns the 9x3 Jacobian of
+  the flattened rotation MATRIX w.r.t. the tangent vector: a different object.
+- `ImuPreintegrator` -- real Forster preintegration: `dR`/`dV`/`dP`, the 9x9
+  covariance (`[theta,v,p]` order), and the five first-order bias Jacobians, so
+  a bias update needs no re-integration. `ImuIntegrator` stays as the cheap
+  ROTATION-ONLY path (its name and docstring still oversell it, see
+  `~/plans/800_imu.md`). Discretization is standard Euler-forward (reading held
+  over the FOLLOWING dt, rotation taken at the step start), chosen over a
+  midpoint rule because it keeps state, Jacobians and covariance mutually
+  consistent; error is first order in dt, far below sensor noise at real rates.
+  Inputs MUST already be body-frame (use `ImuTransformer`); an assertion
+  enforces `sensor_pose` is unset or identity.
+- `MapGravityEstimator` -- estimates the GRAVITY VECTOR IN THE MAP FRAME plus
+  both IMU biases, over a sliding window of intervals, from preintegrated IMU
+  aided by an external odometry's attitudes and velocities. Rearranging the
+  delta definition, `g = (v_j - v_i - R_i dV_ij)/dt`, makes every interval a
+  direct gravity measurement in which body acceleration CANCELS: unlike
+  averaging accelerometers, it stays valid while moving arbitrarily. Unknowns
+  are 9 scalars regardless of window length, so there are no attitude variables
+  and no gauge to pin. `correction()` is the yaw-free rotation that levels the
+  frame; `correction * R_odometry` is the gravity-consistent attitude.
+
+Load-bearing details, do not "simplify" them away:
+- The zero-anchored BIAS PRIORS and the |g| soft constraint are what keep the
+  problem conditioned. Accel bias is only separable from a tilt given ROTATION
+  EXCITATION; on a straight, level, constant-attitude run the two are
+  indistinguishable and the prior is all that bounds the answer.
+- The INTERVAL-COVERAGE GUARD (`min_interval_coverage`, default 0.95) rejects
+  an interval whose IMU samples do not span it. A partial delta attributed to a
+  whole interval corrupts the constraint SILENTLY; this exact bug cost a long
+  debugging session in `mola_mapper`.
+- Rejecting an interval is always safe here (the unknowns are global, so
+  nothing is left unconstrained), unlike a full-state formulation which needs
+  fallback priors.
+- `ImuIntegrationParams` defaults `cov_gyro`/`cov_acc` to IDENTITY, i.e.
+  sigma=1, ~1000x worse than any real MEMS IMU. Always set real noise
+  densities, or every "earned" sigma comes out enormous and the estimator
+  never reports convergence.
+
+See `~/plans/801_lio_imu_preintegration_gravity.md` for the design and status.
+
 ## Build & test
 Standard MOLA/colcon build (see root MOLA repo). Tests are plain executables that return non-zero
 on failure and use MRPT `ASSERT_*` macros.

--- a/include/mola_imu_preintegration/ImuIntegrationParams.h
+++ b/include/mola_imu_preintegration/ImuIntegrationParams.h
@@ -60,14 +60,43 @@ class ImuIntegrationParams
     /// Gyroscope (initial or constant) bias, in the local IMU frame of reference (units: rad/s).
     AngularVelocity bias_gyro = {.0, .0, .0};
 
-    /// Gyroscope covariance (units of sigma are rad/s/√Hz )
-    mrpt::math::CMatrixDouble33 cov_gyro = mrpt::math::CMatrixDouble33::Identity();
+    /// Default gyroscope noise density [rad/s/√Hz], representative of an
+    /// industrial-grade MEMS IMU (~0.01 deg/s/√Hz, e.g. ADIS16448 / Xsens MTi
+    /// class). \sa cov_gyro
+    constexpr static double DEFAULT_GYRO_NOISE_DENSITY = 1.7e-4;
+
+    /// Default accelerometer noise density [m/s²/√Hz], representative of an
+    /// industrial-grade MEMS IMU (~200 µg/√Hz). \sa cov_acc
+    constexpr static double DEFAULT_ACCEL_NOISE_DENSITY = 2.0e-3;
+
+    /// Builds the isotropic covariance matrix for a given noise density.
+    [[nodiscard]] static mrpt::math::CMatrixDouble33 isotropic_cov(double sigma)
+    {
+        mrpt::math::CMatrixDouble33 m;
+        m.setDiagonal(sigma * sigma);
+        return m;
+    }
+
+    /** Gyroscope covariance (units of sigma are rad/s/√Hz).
+     *
+     *  Defaults to DEFAULT_GYRO_NOISE_DENSITY squared, i.e. a typical MEMS
+     *  datasheet figure. Set the real value for your sensor: field deployments
+     *  commonly inflate the datasheet density several-fold to absorb vibration
+     *  and unmodeled dynamics.
+     *
+     *  \note This is a continuous-time noise DENSITY, not a per-sample
+     *        covariance: consumers scale it by the sample period.
+     */
+    mrpt::math::CMatrixDouble33 cov_gyro = isotropic_cov(DEFAULT_GYRO_NOISE_DENSITY);
 
     /// Accelerometer (initial or constant) bias, in the local IMU frame of reference (units: m/s²).
     LinearAcceleration bias_acc = {.0, .0, .0};
 
-    /// Accelerometer covariance (units of sigma are m/s²/√Hz )
-    mrpt::math::CMatrixDouble33 cov_acc = mrpt::math::CMatrixDouble33::Identity();
+    /** Accelerometer covariance (units of sigma are m/s²/√Hz).
+     *  Defaults to DEFAULT_ACCEL_NOISE_DENSITY squared. See cov_gyro for the
+     *  units convention and the caveat about inflating datasheet figures.
+     */
+    mrpt::math::CMatrixDouble33 cov_acc = isotropic_cov(DEFAULT_ACCEL_NOISE_DENSITY);
 
     /// Integration covariance: jerk, that is, how much acceleration can change over time:
     // mrpt::math::CMatrixDouble33 cov_integration = mrpt::math::CMatrixDouble33::Identity();

--- a/include/mola_imu_preintegration/ImuPreintegrator.h
+++ b/include/mola_imu_preintegration/ImuPreintegrator.h
@@ -1,0 +1,188 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   ImuPreintegrator.h
+ * @brief  Full IMU preintegration on manifold (rotation + velocity + position).
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ */
+#pragma once
+
+#include <mola_imu_preintegration/ImuIntegrationParams.h>
+#include <mola_imu_preintegration/so3_jacobians.h>
+#include <mola_imu_preintegration/types.h>
+#include <mrpt/math/CMatrixFixed.h>
+
+#include <cstddef>
+
+namespace mola::imu
+{
+/** Covariance of the preintegrated measurement, ordered as
+ *  `[theta(3) , v(3) , p(3)]`.
+ */
+using PreintegrationCovariance = mrpt::math::CMatrixFixed<double, 9, 9>;
+
+/** The result of preintegrating a set of IMU readings over an interval (i,j],
+ *  around a fixed bias linearization point.
+ *
+ *  The deltas are defined, as usual (Forster et al. 2015), in the body frame
+ *  of the interval start `i`:
+ *
+ *      dR_ij = R_i^T R_j
+ *      dV_ij = R_i^T (v_j - v_i - g * dt_ij)
+ *      dP_ij = R_i^T (p_j - p_i - v_i*dt_ij - 0.5*g*dt_ij^2)
+ *
+ *  so that gravity never enters the integration itself: it is introduced only
+ *  when the delta is compared against a pair of states.
+ *
+ *  \ingroup mola_imu_preintegration_grp
+ */
+struct PreintegratedImuMeasurements
+{
+    PreintegratedImuMeasurements() = default;
+
+    /// Time span covered by the integrated samples [s]. NOTE: this is the sum
+    /// of the actual sample dt's, which is NOT necessarily the wall-clock
+    /// duration of the interval (see the coverage guard in
+    /// MapGravityEstimator).
+    double deltaTij = 0;
+
+    SO3                   deltaRij = SO3::Identity();  //!< Preintegrated rotation
+    LinearVelocity        deltaVij{0, 0, 0};  //!< Preintegrated velocity
+    mrpt::math::TVector3D deltaPij{0, 0, 0};  //!< Preintegrated position
+
+    /** \name First-order bias-update Jacobians
+     *  Defined such that, for a bias increment `db` w.r.t. the linearization
+     *  point, `dR(b) ~= dR_bar * Exp(dR_dbg * db_g)`,
+     *  `dV(b) ~= dV_bar + dV_dba * db_a + dV_dbg * db_g`, and likewise for dP.
+     *  @{ */
+    mrpt::math::CMatrixDouble33 dR_dbg = mrpt::math::CMatrixDouble33::Zero();
+    mrpt::math::CMatrixDouble33 dV_dba = mrpt::math::CMatrixDouble33::Zero();
+    mrpt::math::CMatrixDouble33 dV_dbg = mrpt::math::CMatrixDouble33::Zero();
+    mrpt::math::CMatrixDouble33 dP_dba = mrpt::math::CMatrixDouble33::Zero();
+    mrpt::math::CMatrixDouble33 dP_dbg = mrpt::math::CMatrixDouble33::Zero();
+    /** @} */
+
+    /// Propagated covariance of the preintegrated measurement, ordered
+    /// `[theta, v, p]`. Only the noise of the raw readings is propagated here;
+    /// bias uncertainty is handled by the estimator via the Jacobians above.
+    PreintegrationCovariance cov = PreintegrationCovariance::Zero();
+
+    /// The bias linearization point these deltas and Jacobians refer to.
+    LinearAcceleration bias_acc{0, 0, 0};
+    AngularVelocity    bias_gyro{0, 0, 0};
+
+    /// Number of raw samples integrated.
+    std::size_t num_measurements = 0;
+
+    /// Bias-corrected deltas, to first order, for a new bias estimate.
+    struct BiasCorrectedDelta
+    {
+        SO3                   deltaRij = SO3::Identity();
+        LinearVelocity        deltaVij{0, 0, 0};
+        mrpt::math::TVector3D deltaPij{0, 0, 0};
+    };
+
+    /** Applies the first-order bias update to obtain the deltas that would
+     *  have resulted from integrating around `(newBiasAcc, newBiasGyro)`,
+     *  WITHOUT re-integrating the raw samples. This is the whole point of
+     *  preintegration.
+     */
+    BiasCorrectedDelta bias_corrected(
+        const LinearAcceleration& newBiasAcc, const AngularVelocity& newBiasGyro) const;
+};
+
+/** Integrates accelerometer and gyroscope readings into a
+ *  PreintegratedImuMeasurements, following:
+ *
+ *  Forster, C., Carlone, L., Dellaert, F., & Scaramuzza, D. (2017). On-manifold
+ *  preintegration for real-time visual-inertial odometry. IEEE Transactions on
+ *  Robotics, 33(1), 1-21.
+ *
+ *  Unlike ImuIntegrator (which is rotation-only), this class propagates the
+ *  full `(dR, dV, dP)` triplet together with its covariance and the
+ *  first-order bias Jacobians.
+ *
+ *  \note Readings MUST already be expressed in the vehicle/body frame,
+ *        including any lever-arm compensation: use ImuTransformer for that.
+ *        `parameters.sensor_pose` is therefore IGNORED by this class (an
+ *        assertion enforces it is unset or the identity).
+ *
+ *  \note The accelerometer reading is the proper acceleration (specific
+ *        force): at rest with the body Z axis up it reads `(0,0,+9.81)`.
+ *        Gravity is deliberately NOT subtracted here, see
+ *        PreintegratedImuMeasurements.
+ *
+ *  \note Discretization convention: each reading is held CONSTANT over the
+ *        FOLLOWING `dt`, and the rotation used to rotate the acceleration is
+ *        the one at the START of the step. This is the standard Euler-forward
+ *        form of Forster et al. (and of GTSAM's implementation), which keeps
+ *        the state propagation, the bias Jacobians and the covariance exactly
+ *        consistent with one another. Its `dV`/`dP` discretization error is
+ *        first order in `dt`, which at any realistic IMU rate is far below the
+ *        sensor's own noise and bias errors. `dR` is unaffected whenever the
+ *        angular rate is (piecewise) constant.
+ *
+ *  Usage:
+ *  - (1) set `parameters` (noise densities + the bias linearization point),
+ *  - (2) reset_integration(),
+ *  - (3) integrate_measurement() for every sample of the interval,
+ *  - (4) take current_state(), then go back to (2) for the next interval.
+ *
+ *  \ingroup mola_imu_preintegration_grp
+ */
+class ImuPreintegrator
+{
+   public:
+    ImuPreintegrator() = default;
+    explicit ImuPreintegrator(const ImuIntegrationParams& p) : parameters(p) {}
+
+    /// All public parameters, including the bias linearization point and the
+    /// continuous-time noise densities `cov_gyro` / `cov_acc`.
+    ImuIntegrationParams parameters;
+
+    /** Resets the accumulated state, keeping the bias linearization point
+     *  currently held in `parameters`.
+     */
+    void reset_integration();
+
+    /** Resets the accumulated state and sets a new bias linearization point.
+     */
+    void reset_integration(const LinearAcceleration& biasAcc, const AngularVelocity& biasGyro);
+
+    /** Accumulates one IMU sample, held constant over `dt` seconds.
+     *  @param a  Proper acceleration in the body frame [m/s^2].
+     *  @param w  Angular velocity in the body frame [rad/s].
+     *  @param dt Time step [s]; must be > 0.
+     */
+    void integrate_measurement(const LinearAcceleration& a, const AngularVelocity& w, double dt);
+
+    const PreintegratedImuMeasurements& current_state() const { return state_; }
+
+   private:
+    PreintegratedImuMeasurements state_;
+};
+
+}  // namespace mola::imu
+
+/** Feature macro: the package provides full on-manifold IMU preintegration
+ *  (rotation + velocity + position, with covariance propagation and
+ *  first-order bias Jacobians) via ImuPreintegrator, plus the SO(3) right
+ *  Jacobian helpers in so3_jacobians.h. Downstream packages in separate repos
+ *  should guard usage with
+ *  `#if defined(MOLA_IMU_PREINTEGRATION_HAS_FULL_PREINTEGRATION)` to remain
+ *  buildable against older checkouts.
+ */
+#define MOLA_IMU_PREINTEGRATION_HAS_FULL_PREINTEGRATION 1

--- a/include/mola_imu_preintegration/MapGravityEstimator.h
+++ b/include/mola_imu_preintegration/MapGravityEstimator.h
@@ -1,0 +1,278 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   MapGravityEstimator.h
+ * @brief  Estimates the gravity vector in the odometry/map frame, from
+ *         preintegrated IMU plus externally-supplied poses and velocities.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ */
+#pragma once
+
+#include <mola_imu_preintegration/ImuPreintegrator.h>
+#include <mrpt/containers/yaml.h>
+
+#include <cstddef>
+#include <deque>
+#include <optional>
+#include <string>
+
+namespace mola::imu
+{
+/** Estimates the GRAVITY VECTOR IN THE MAP FRAME (plus the IMU biases) from
+ *  preintegrated IMU measurements, using the attitudes and velocities of an
+ *  external odometry source (e.g. LiDAR odometry) over a sliding window.
+ *
+ *  ### The idea
+ *
+ *  The preintegrated velocity delta satisfies, exactly,
+ *
+ *      R_i * dV_ij  =  v_j - v_i - g * dt_ij
+ *
+ *  so, rearranged,
+ *
+ *      g  =  ( v_j - v_i - R_i * dV_ij ) / dt_ij
+ *
+ *  Every interval is therefore a direct measurement of gravity expressed in
+ *  whatever frame `R` and `v` live in, i.e. the odometry/map frame. Body
+ *  acceleration is carried by `dV_ij` and cancels out, which is exactly what
+ *  averaging raw accelerometer samples cannot do: that only works while the
+ *  vehicle is quasi-static, whereas this works under arbitrary motion.
+ *
+ *  How far the estimated `g` has departed from `(0, 0, -g)` IS the tilt the
+ *  map has accumulated, and `correction()` is the rotation that removes it.
+ *
+ *  ### What is estimated, and what is trusted
+ *
+ *  Unknowns are just `(g, bias_acc, bias_gyro)`: NINE scalars, regardless of
+ *  the window length. There are deliberately no per-keyframe attitude
+ *  variables:
+ *  - the external odometry's RELATIVE rotations over a short window are
+ *    accurate (that is the strength of scan matching); it is the ABSOLUTE
+ *    tilt that drifts, and that is precisely what `g` absorbs;
+ *  - with no absolute-attitude variables there is no gauge freedom to pin and
+ *    no frame-mismatch between the IMU's gravity-aligned world and the
+ *    odometry's map frame.
+ *
+ *  The gyroscope bias stays observable through a second residual comparing the
+ *  preintegrated rotation against the external odometry's relative rotation.
+ *
+ *  ### Observability caveat (do not remove the bias priors)
+ *
+ *  The accelerometer bias is only separable from a small tilt given ROTATION
+ *  EXCITATION: on a perfectly straight, level, constant-attitude run, a bias
+ *  and a tilt are indistinguishable. The zero-anchored bias priors are
+ *  therefore load-bearing, not decorative. Likewise, the gravity-magnitude
+ *  soft constraint is what keeps the direction well conditioned when the
+ *  velocity data is weak.
+ *
+ *  Thread-safety: none. Callers serialize access externally.
+ *
+ *  \ingroup mola_imu_preintegration_grp
+ */
+class MapGravityEstimator
+{
+   public:
+    MapGravityEstimator() = default;
+
+    struct Parameters
+    {
+        Parameters() = default;
+
+        /// Number of intervals kept in the sliding window.
+        std::size_t window_size = 20;
+
+        /// Nominal local gravity magnitude [m/s^2].
+        double gravity_magnitude = 9.81;
+
+        /// Sigma of the soft constraint on |g| [m/s^2]. Keeps the direction
+        /// well conditioned; loose enough to absorb a real local-gravity or
+        /// scale-factor discrepancy.
+        double gravity_magnitude_sigma = 0.05;
+
+        /// An interval whose integrated time spans less than this fraction of
+        /// its wall-clock duration is REJECTED: a partially covered interval
+        /// yields a delta that does not span the gap, which would silently
+        /// corrupt the constraint.
+        double min_interval_coverage = 0.95;
+
+        /// Intervals outside this duration range [s] are rejected. Too short
+        /// makes `g = (...)/dt` ill-conditioned; too long breaks the
+        /// constant-bias and first-order-bias-update assumptions.
+        double min_interval_duration = 0.05;
+        double max_interval_duration = 30.0;
+
+        /// Assumed sigma of the external odometry's RELATIVE rotation over one
+        /// interval [degrees]. Only affects how strongly the gyro bias is
+        /// pulled toward agreeing with the odometry.
+        double odometry_relative_rotation_sigma_deg = 0.5;
+
+        /// Sigma of the zero-anchored accelerometer bias prior [m/s^2].
+        double bias_acc_prior_sigma = 0.15;
+
+        /// Sigma of the zero-anchored gyroscope bias prior [rad/s].
+        double bias_gyro_prior_sigma = 0.01;
+
+        /// Huber threshold applied to the whitened gravity residuals, so a bad
+        /// odometry velocity or a jolt cannot drag the estimate.
+        double huber_threshold = 2.0;
+
+        std::size_t max_iterations = 10;
+
+        /// Gauss-Newton stops when the increment norm falls below this.
+        double tolerance = 1e-10;
+
+        /// Minimum number of intervals in the window before the result is
+        /// reported as converged.
+        std::size_t min_intervals_for_convergence = 4;
+
+        /// The result is not reported as converged while the estimated tilt
+        /// sigma exceeds this [degrees].
+        double max_tilt_sigma_deg = 3.0;
+
+        void load_from(const mrpt::containers::yaml& cfg);
+        void save_to(mrpt::containers::yaml& cfg) const;
+    };
+
+    Parameters parameters;
+
+    /** One inter-keyframe interval: the preintegrated IMU delta plus the
+     *  external odometry's attitude and velocity at both ends, all expressed
+     *  in the same (map/odometry) frame.
+     */
+    struct Interval
+    {
+        Interval() = default;
+
+        TimeStamp t_from = 0;
+        TimeStamp t_to   = 0;
+
+        /// Preintegrated over `(t_from, t_to]`.
+        PreintegratedImuMeasurements delta;
+
+        SO3 R_from = SO3::Identity();  //!< odometry attitude (map <- body) at t_from
+        SO3 R_to   = SO3::Identity();  //!< odometry attitude (map <- body) at t_to
+
+        LinearVelocity v_from{0, 0, 0};  //!< map-frame velocity at t_from
+        LinearVelocity v_to{0, 0, 0};  //!< map-frame velocity at t_to
+
+        /// Map-frame covariances of the velocities above. Defaults are
+        /// deliberately loose; supply the real ones when available.
+        mrpt::math::CMatrixDouble33 cov_v_from = defaultVelocityCov();
+        mrpt::math::CMatrixDouble33 cov_v_to   = defaultVelocityCov();
+
+        static mrpt::math::CMatrixDouble33 defaultVelocityCov();
+    };
+
+    /// The estimator's output.
+    struct Result
+    {
+        Result() = default;
+
+        TimeStamp timestamp = 0;  //!< stamp of the newest interval's end
+
+        /// The estimated gravity vector in the map frame [m/s^2]. Points
+        /// DOWN, i.e. close to `(0, 0, -9.81)` while the map is level.
+        mrpt::math::TVector3D gravity_in_map{0, 0, -9.81};
+
+        /// Rotation that takes the map frame to a gravity-aligned one, with no
+        /// yaw component. Left-multiply an odometry attitude by this to obtain
+        /// the gravity-corrected attitude:  `R_corrected = correction * R_odom`.
+        SO3 correction = SO3::Identity();
+
+        /// The pitch/roll of `correction` [rad], i.e. how tilted the map has
+        /// become, and their "earned" sigmas propagated from the solved
+        /// information matrix. Consumers should weight the estimate with these
+        /// instead of a hand-tuned constant.
+        double pitch_correction = 0;
+        double roll_correction  = 0;
+        double pitch_sigma      = 0;
+        double roll_sigma       = 0;
+
+        /// Total tilt angle of `correction` [rad].
+        double tilt = 0;
+
+        LinearAcceleration bias_acc{0, 0, 0};
+        AngularVelocity    bias_gyro{0, 0, 0};
+
+        std::size_t num_intervals = 0;
+        std::size_t iterations    = 0;
+        bool        converged     = false;
+    };
+
+    /** Minimal rotation (no yaw) taking the "up" direction implied by a
+     *  gravity vector onto `+Z`, i.e. the correction that levels a frame in
+     *  which gravity is measured as `gravityInMap`.
+     *  Returns the identity for a degenerate (near-zero) input.
+     */
+    static SO3 correction_from_gravity(const mrpt::math::TVector3D& gravityInMap);
+
+    /** Sets the center of the bias priors, e.g. from a calibration at rest
+     *  (ImuInitialCalibrator). Defaults to zero.
+     */
+    void set_bias_prior(const LinearAcceleration& biasAcc, const AngularVelocity& biasGyro);
+
+    /** Appends one interval to the window, dropping the oldest when full.
+     *
+     *  @return false if the interval was REJECTED by the input guards
+     *          (insufficient IMU coverage, empty, non-finite, out of order,
+     *          implausible duration). Rejecting is always safe here: the
+     *          unknowns are global, so a skipped interval leaves nothing
+     *          unconstrained.
+     */
+    bool add_interval(const Interval& interval);
+
+    /// Reason the last add_interval() returned false (for logging).
+    const std::string& last_rejection_reason() const { return last_rejection_reason_; }
+
+    /** Runs Gauss-Newton over the current window.
+     *  @return false if there is not enough data, or the solve failed.
+     */
+    bool solve();
+
+    /// The result of the last successful solve(), if any.
+    const std::optional<Result>& latest_result() const { return latest_result_; }
+
+    /// Number of intervals currently in the window.
+    std::size_t window_length() const { return intervals_.size(); }
+
+    /// Clears the window, keeping parameters and bias priors.
+    void reset();
+
+   private:
+    std::deque<Interval> intervals_;
+
+    mrpt::math::TVector3D gravity_{0, 0, -9.81};
+    LinearAcceleration    bias_acc_{0, 0, 0};
+    AngularVelocity       bias_gyro_{0, 0, 0};
+
+    LinearAcceleration bias_acc_prior_{0, 0, 0};
+    AngularVelocity    bias_gyro_prior_{0, 0, 0};
+
+    bool gravity_initialized_ = false;
+
+    std::optional<Result> latest_result_;
+    std::string           last_rejection_reason_;
+
+    bool reject(const std::string& why);
+};
+
+}  // namespace mola::imu
+
+/** Feature macro: the package provides MapGravityEstimator, which estimates
+ *  the gravity vector in the odometry/map frame (and the IMU biases) from
+ *  preintegrated IMU measurements aided by external poses and velocities.
+ */
+#define MOLA_IMU_PREINTEGRATION_HAS_MAP_GRAVITY_ESTIMATOR 1

--- a/include/mola_imu_preintegration/so3_jacobians.h
+++ b/include/mola_imu_preintegration/so3_jacobians.h
@@ -1,0 +1,69 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   so3_jacobians.h
+ * @brief  SO(3) right Jacobian and small helpers used by IMU preintegration.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ */
+#pragma once
+
+#include <mola_imu_preintegration/types.h>
+#include <mrpt/math/CMatrixFixed.h>
+#include <mrpt/math/TPoint3D.h>
+
+namespace mola::imu
+{
+/** Skew-symmetric ("hat") matrix of a 3-vector, such that
+ *  `skew_symmetric(a) * b == a.cross(b)`.
+ */
+mrpt::math::CMatrixDouble33 skew_symmetric(const mrpt::math::TVector3D& v);
+
+/** SO(3) exponential map, `phi -> Exp(phi)`. Thin wrapper over
+ *  `mrpt::poses::Lie::SO<3>::exp()` taking a TVector3D.
+ */
+SO3 so3_exp(const mrpt::math::TVector3D& phi);
+
+/** SO(3) logarithm map, `R -> Log(R)`. Thin wrapper over
+ *  `mrpt::poses::Lie::SO<3>::log()` returning a TVector3D.
+ */
+mrpt::math::TVector3D so3_log(const SO3& R);
+
+/** Right Jacobian of SO(3), `Jr(phi)`, defined by the first-order identity
+ *
+ *    Exp(phi + delta) ~= Exp(phi) * Exp( Jr(phi) * delta )
+ *
+ *  Closed form:
+ *
+ *    Jr = I - ((1-cos t)/t^2) K + ((t - sin t)/t^3) K^2,   K = skew(phi), t = |phi|
+ *
+ *  A Taylor expansion is used for small `t` to avoid the catastrophic
+ *  cancellation of `t - sin(t)`.
+ *
+ *  \note This is NOT what `mrpt::poses::Lie::SO<3>::jacob_dexpe_de()` returns:
+ *        that one is the 9x3 Jacobian of the (column-major flattened) rotation
+ *        matrix w.r.t. the tangent vector, a different object.
+ */
+mrpt::math::CMatrixDouble33 right_jacobian_so3(const mrpt::math::TVector3D& phi);
+
+/** Inverse of right_jacobian_so3(), in closed form:
+ *
+ *    Jr^-1 = I + K/2 + ( 1/t^2 - (1+cos t)/(2 t sin t) ) K^2
+ *
+ *  with a Taylor expansion for small `t`.
+ */
+mrpt::math::CMatrixDouble33 inverse_right_jacobian_so3(const mrpt::math::TVector3D& phi);
+
+}  // namespace mola::imu

--- a/src/ImuPreintegrator.cpp
+++ b/src/ImuPreintegrator.cpp
@@ -1,0 +1,154 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   ImuPreintegrator.cpp
+ * @brief  Full IMU preintegration on manifold (rotation + velocity + position).
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ */
+
+#include <mola_imu_preintegration/ImuPreintegrator.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/math/TPose3D.h>
+
+#include <Eigen/Dense>
+
+using namespace mola::imu;
+
+namespace
+{
+/// Converts a TVector3D into an Eigen column vector.
+Eigen::Vector3d toEigen(const mrpt::math::TVector3D& v) { return {v.x, v.y, v.z}; }
+
+/// Converts an Eigen column vector into a TVector3D.
+mrpt::math::TVector3D fromEigen(const Eigen::Vector3d& v) { return {v.x(), v.y(), v.z()}; }
+}  // namespace
+
+PreintegratedImuMeasurements::BiasCorrectedDelta PreintegratedImuMeasurements::bias_corrected(
+    const LinearAcceleration& newBiasAcc, const AngularVelocity& newBiasGyro) const
+{
+    const Eigen::Vector3d dba = toEigen(newBiasAcc - bias_acc);
+    const Eigen::Vector3d dbg = toEigen(newBiasGyro - bias_gyro);
+
+    BiasCorrectedDelta out;
+
+    // Rotation: a right-multiplied correction on the manifold.
+    const auto dPhi        = fromEigen(Eigen::Vector3d(dR_dbg.asEigen() * dbg));
+    out.deltaRij.asEigen() = deltaRij.asEigen() * so3_exp(dPhi).asEigen();
+
+    // Velocity and position: plain vector-space first-order corrections.
+    out.deltaVij =
+        deltaVij + fromEigen(Eigen::Vector3d(dV_dba.asEigen() * dba + dV_dbg.asEigen() * dbg));
+    out.deltaPij =
+        deltaPij + fromEigen(Eigen::Vector3d(dP_dba.asEigen() * dba + dP_dbg.asEigen() * dbg));
+
+    return out;
+}
+
+void ImuPreintegrator::reset_integration()
+{
+    reset_integration(parameters.bias_acc, parameters.bias_gyro);
+}
+
+void ImuPreintegrator::reset_integration(
+    const LinearAcceleration& biasAcc, const AngularVelocity& biasGyro)
+{
+    state_           = PreintegratedImuMeasurements();
+    state_.bias_acc  = biasAcc;
+    state_.bias_gyro = biasGyro;
+
+    // Keep `parameters` in sync, so that a caller reading them back sees the
+    // linearization point actually in use:
+    parameters.bias_acc  = biasAcc;
+    parameters.bias_gyro = biasGyro;
+}
+
+void ImuPreintegrator::integrate_measurement(
+    const LinearAcceleration& a, const AngularVelocity& w, double dt)
+{
+    ASSERT_GT_(dt, 0);
+    ASSERTMSG_(
+        !parameters.sensor_pose.has_value() ||
+            parameters.sensor_pose->asTPose() == mrpt::math::TPose3D::Identity(),
+        "ImuPreintegrator expects readings already in the body frame: "
+        "parameters.sensor_pose must be unset or the identity (use "
+        "ImuTransformer to move raw readings to the body frame).");
+
+    // Bias-corrected readings, at the linearization point:
+    const Eigen::Vector3d acc  = toEigen(a - state_.bias_acc);
+    const Eigen::Vector3d gyro = toEigen(w - state_.bias_gyro);
+
+    const mrpt::math::TVector3D phi     = fromEigen(Eigen::Vector3d(gyro * dt));
+    const auto                  incrR   = so3_exp(phi);
+    const auto                  Jr      = right_jacobian_so3(phi);
+    const Eigen::Matrix3d       incrR_e = incrR.asEigen();
+    const Eigen::Matrix3d       Jr_e    = Jr.asEigen();
+
+    const Eigen::Matrix3d dR_e   = state_.deltaRij.asEigen();
+    const Eigen::Matrix3d accHat = skew_symmetric(fromEigen(acc)).asEigen();
+
+    // ---- Covariance propagation (order: [theta, v, p]) --------------------
+    // Must run BEFORE the state is advanced, since A and B are built at the
+    // current linearization point.
+    {
+        Eigen::Matrix<double, 9, 9> A = Eigen::Matrix<double, 9, 9>::Identity();
+        A.block<3, 3>(0, 0)           = incrR_e.transpose();
+        A.block<3, 3>(3, 0)           = -dR_e * accHat * dt;
+        A.block<3, 3>(6, 0)           = -0.5 * dR_e * accHat * dt * dt;
+        A.block<3, 3>(6, 3)           = Eigen::Matrix3d::Identity() * dt;
+
+        Eigen::Matrix<double, 9, 3> Bg = Eigen::Matrix<double, 9, 3>::Zero();
+        Bg.block<3, 3>(0, 0)           = Jr_e * dt;
+
+        Eigen::Matrix<double, 9, 3> Ba = Eigen::Matrix<double, 9, 3>::Zero();
+        Ba.block<3, 3>(3, 0)           = dR_e * dt;
+        Ba.block<3, 3>(6, 0)           = 0.5 * dR_e * dt * dt;
+
+        // cov_gyro / cov_acc are continuous-time noise DENSITIES, so the
+        // discrete-time covariance over this step is density/dt.
+        const Eigen::Matrix3d covG = parameters.cov_gyro.asEigen() / dt;
+        const Eigen::Matrix3d covA = parameters.cov_acc.asEigen() / dt;
+
+        state_.cov.asEigen() = A * state_.cov.asEigen() * A.transpose() +
+                               Bg * covG * Bg.transpose() + Ba * covA * Ba.transpose();
+    }
+
+    // ---- Bias Jacobians ---------------------------------------------------
+    // Also before advancing dR, for the same reason.
+    {
+        const Eigen::Matrix3d dR_dbg_prev = state_.dR_dbg.asEigen();
+        const Eigen::Matrix3d dV_dba_prev = state_.dV_dba.asEigen();
+        const Eigen::Matrix3d dV_dbg_prev = state_.dV_dbg.asEigen();
+
+        state_.dP_dba.asEigen() += dV_dba_prev * dt - 0.5 * dR_e * dt * dt;
+        state_.dP_dbg.asEigen() += dV_dbg_prev * dt - 0.5 * dR_e * accHat * dR_dbg_prev * dt * dt;
+
+        state_.dV_dba.asEigen() -= dR_e * dt;
+        state_.dV_dbg.asEigen() -= dR_e * accHat * dR_dbg_prev * dt;
+
+        state_.dR_dbg.asEigen() = incrR_e.transpose() * dR_dbg_prev - Jr_e * dt;
+    }
+
+    // ---- State propagation ------------------------------------------------
+    // Position first (it uses the pre-update velocity and rotation), then
+    // velocity, then rotation.
+    state_.deltaPij = state_.deltaPij + state_.deltaVij * dt +
+                      fromEigen(Eigen::Vector3d(0.5 * dR_e * acc)) * dt * dt;
+    state_.deltaVij           = state_.deltaVij + fromEigen(Eigen::Vector3d(dR_e * acc)) * dt;
+    state_.deltaRij.asEigen() = dR_e * incrR_e;
+
+    state_.deltaTij += dt;
+    state_.num_measurements++;
+}

--- a/src/MapGravityEstimator.cpp
+++ b/src/MapGravityEstimator.cpp
@@ -1,0 +1,501 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   MapGravityEstimator.cpp
+ * @brief  Estimates the gravity vector in the odometry/map frame.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ */
+
+#include <mola_imu_preintegration/MapGravityEstimator.h>
+#include <mrpt/core/bits_math.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <Eigen/Dense>
+#include <cmath>
+
+using namespace mola::imu;
+
+namespace
+{
+Eigen::Vector3d       toEigen(const mrpt::math::TVector3D& v) { return {v.x, v.y, v.z}; }
+mrpt::math::TVector3D fromEigen(const Eigen::Vector3d& v) { return {v.x(), v.y(), v.z()}; }
+
+bool isFinite(const mrpt::math::TVector3D& v)
+{
+    return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
+}
+
+/// Extracts (pitch, roll) from a rotation matrix.
+std::pair<double, double> pitchRollOf(const SO3& R)
+{
+    mrpt::poses::CPose3D p;
+    p.setRotationMatrix(R);
+    return {p.pitch(), p.roll()};
+}
+
+/// Ridge added to the normal equations, purely for numerical safety of the
+/// LDLT: small enough to be irrelevant next to any real information.
+constexpr double NUMERIC_RIDGE = 1e-12;
+
+/// Below this vector norm a direction is considered undefined.
+constexpr double DIRECTION_EPS = 1e-9;
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+void MapGravityEstimator::Parameters::load_from(const mrpt::containers::yaml& cfg)
+{
+    MCP_LOAD_OPT(cfg, window_size);
+    MCP_LOAD_OPT(cfg, gravity_magnitude);
+    MCP_LOAD_OPT(cfg, gravity_magnitude_sigma);
+    MCP_LOAD_OPT(cfg, min_interval_coverage);
+    MCP_LOAD_OPT(cfg, min_interval_duration);
+    MCP_LOAD_OPT(cfg, max_interval_duration);
+    MCP_LOAD_OPT(cfg, odometry_relative_rotation_sigma_deg);
+    MCP_LOAD_OPT(cfg, bias_acc_prior_sigma);
+    MCP_LOAD_OPT(cfg, bias_gyro_prior_sigma);
+    MCP_LOAD_OPT(cfg, huber_threshold);
+    MCP_LOAD_OPT(cfg, max_iterations);
+    MCP_LOAD_OPT(cfg, tolerance);
+    MCP_LOAD_OPT(cfg, min_intervals_for_convergence);
+    MCP_LOAD_OPT(cfg, max_tilt_sigma_deg);
+
+    ASSERT_GT_(window_size, 0U);
+    ASSERT_GT_(gravity_magnitude, 0.0);
+    ASSERT_GT_(gravity_magnitude_sigma, 0.0);
+    ASSERT_GT_(min_interval_coverage, 0.0);
+    ASSERT_GT_(min_interval_duration, 0.0);
+    ASSERT_GT_(max_interval_duration, min_interval_duration);
+    ASSERT_GT_(odometry_relative_rotation_sigma_deg, 0.0);
+    ASSERT_GT_(bias_acc_prior_sigma, 0.0);
+    ASSERT_GT_(bias_gyro_prior_sigma, 0.0);
+    ASSERT_GT_(huber_threshold, 0.0);
+}
+
+void MapGravityEstimator::Parameters::save_to(mrpt::containers::yaml& cfg) const
+{
+    MCP_SAVE(cfg, window_size);
+    MCP_SAVE(cfg, gravity_magnitude);
+    MCP_SAVE(cfg, gravity_magnitude_sigma);
+    MCP_SAVE(cfg, min_interval_coverage);
+    MCP_SAVE(cfg, min_interval_duration);
+    MCP_SAVE(cfg, max_interval_duration);
+    MCP_SAVE(cfg, odometry_relative_rotation_sigma_deg);
+    MCP_SAVE(cfg, bias_acc_prior_sigma);
+    MCP_SAVE(cfg, bias_gyro_prior_sigma);
+    MCP_SAVE(cfg, huber_threshold);
+    MCP_SAVE(cfg, max_iterations);
+    MCP_SAVE(cfg, tolerance);
+    MCP_SAVE(cfg, min_intervals_for_convergence);
+    MCP_SAVE(cfg, max_tilt_sigma_deg);
+}
+
+mrpt::math::CMatrixDouble33 MapGravityEstimator::Interval::defaultVelocityCov()
+{
+    mrpt::math::CMatrixDouble33 c;
+    c.setDiagonal(mrpt::square(0.25));  // 0.25 m/s, deliberately loose
+    return c;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+SO3 MapGravityEstimator::correction_from_gravity(const mrpt::math::TVector3D& gravityInMap)
+{
+    // The "up" direction implied by the measured gravity:
+    const double n = gravityInMap.norm();
+    if (n < DIRECTION_EPS)
+    {
+        return SO3::Identity();
+    }
+    const Eigen::Vector3d up = -toEigen(gravityInMap) / n;
+    const Eigen::Vector3d z(0, 0, 1);
+
+    // Minimal rotation taking `up` onto +Z: axis = up x z, angle between them.
+    // Being the minimal (geodesic) rotation, it has no yaw component by
+    // construction, so it re-levels the frame without spinning it.
+    const Eigen::Vector3d axis = up.cross(z);
+    const double          s    = axis.norm();
+    const double          c    = up.dot(z);
+
+    if (s < DIRECTION_EPS)
+    {
+        if (c > 0)
+        {
+            return SO3::Identity();  // already aligned
+        }
+        // Antiparallel: any perpendicular axis is valid; pick X.
+        return so3_exp({M_PI, 0, 0});
+    }
+
+    const double angle = std::atan2(s, c);
+    return so3_exp(fromEigen(Eigen::Vector3d(axis / s * angle)));
+}
+
+void MapGravityEstimator::set_bias_prior(
+    const LinearAcceleration& biasAcc, const AngularVelocity& biasGyro)
+{
+    bias_acc_prior_  = biasAcc;
+    bias_gyro_prior_ = biasGyro;
+    if (intervals_.empty())
+    {
+        bias_acc_  = biasAcc;
+        bias_gyro_ = biasGyro;
+    }
+}
+
+void MapGravityEstimator::reset()
+{
+    intervals_.clear();
+    latest_result_.reset();
+    last_rejection_reason_.clear();
+    gravity_initialized_ = false;
+    bias_acc_            = bias_acc_prior_;
+    bias_gyro_           = bias_gyro_prior_;
+}
+
+bool MapGravityEstimator::reject(const std::string& why)
+{
+    last_rejection_reason_ = why;
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Window management
+// ---------------------------------------------------------------------------
+bool MapGravityEstimator::add_interval(const Interval& interval)
+{
+    const auto& d = interval.delta;
+
+    // ---- Input guards. Rejecting is safe: the unknowns are global, so a
+    //      skipped interval leaves nothing unconstrained. -------------------
+    if (d.num_measurements == 0)
+    {
+        return reject("no IMU samples in the interval");
+    }
+
+    const double wallDt = interval.t_to - interval.t_from;
+    if (!(wallDt > 0))
+    {
+        return reject(mrpt::format("non-positive interval duration (%g s)", wallDt));
+    }
+    if (wallDt < parameters.min_interval_duration)
+    {
+        return reject(mrpt::format(
+            "interval too short (%g s < %g s)", wallDt, parameters.min_interval_duration));
+    }
+    if (wallDt > parameters.max_interval_duration)
+    {
+        return reject(mrpt::format(
+            "interval too long (%g s > %g s)", wallDt, parameters.max_interval_duration));
+    }
+    if (!(d.deltaTij > 0))
+    {
+        return reject("non-positive integrated time");
+    }
+
+    // The coverage guard: a partially covered interval yields a delta that
+    // does NOT span the gap, silently corrupting the constraint.
+    const double coverage = d.deltaTij / wallDt;
+    if (coverage < parameters.min_interval_coverage)
+    {
+        return reject(mrpt::format(
+            "insufficient IMU coverage of the interval: %.1f%% < %.1f%% (integrated %g s of "
+            "%g s, %zu samples)",
+            100.0 * coverage, 100.0 * parameters.min_interval_coverage, d.deltaTij, wallDt,
+            d.num_measurements));
+    }
+
+    if (!isFinite(interval.v_from) || !isFinite(interval.v_to) || !isFinite(d.deltaVij) ||
+        !d.deltaRij.asEigen().allFinite() || !interval.R_from.asEigen().allFinite() ||
+        !interval.R_to.asEigen().allFinite())
+    {
+        return reject("non-finite values in the interval");
+    }
+
+    // Consecutive intervals are expected to chain exactly (t_from == previous
+    // t_to); a small tolerance keeps floating-point stamp arithmetic from
+    // tripping the guard, without letting genuinely out-of-order data through.
+    constexpr double STAMP_TOLERANCE = 1e-6;  // [s]
+    if (!intervals_.empty() && interval.t_from < intervals_.back().t_to - STAMP_TOLERANCE)
+    {
+        return reject(mrpt::format(
+            "out-of-order interval (t_from=%.6f < newest t_to=%.6f)", interval.t_from,
+            intervals_.back().t_to));
+    }
+
+    intervals_.push_back(interval);
+
+    while (intervals_.size() > parameters.window_size)
+    {
+        intervals_.pop_front();
+    }
+
+    if (!gravity_initialized_)
+    {
+        gravity_             = {0, 0, -parameters.gravity_magnitude};
+        gravity_initialized_ = true;
+    }
+
+    last_rejection_reason_.clear();
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Solver: Gauss-Newton over x = [ g (3), bias_gyro (3), bias_acc (3) ]
+// ---------------------------------------------------------------------------
+bool MapGravityEstimator::solve()
+{
+    if (intervals_.empty())
+    {
+        return false;
+    }
+
+    constexpr Eigen::Index IDX_G  = 0;
+    constexpr Eigen::Index IDX_BG = 3;
+    constexpr Eigen::Index IDX_BA = 6;
+    constexpr Eigen::Index N      = 9;
+
+    const double wBa  = 1.0 / parameters.bias_acc_prior_sigma;
+    const double wBg  = 1.0 / parameters.bias_gyro_prior_sigma;
+    const double wMag = 1.0 / parameters.gravity_magnitude_sigma;
+    const double covOdomRot =
+        mrpt::square(mrpt::DEG2RAD(parameters.odometry_relative_rotation_sigma_deg));
+    const double huberK = parameters.huber_threshold;
+
+    Eigen::Matrix<double, N, N> H              = Eigen::Matrix<double, N, N>::Zero();
+    std::size_t                 iterationsDone = 0;
+
+    for (std::size_t iter = 0; iter < parameters.max_iterations; iter++)
+    {
+        H.setZero();
+        Eigen::Matrix<double, N, 1> b = Eigen::Matrix<double, N, 1>::Zero();
+
+        for (const auto& itv : intervals_)
+        {
+            const auto& d = itv.delta;
+
+            const Eigen::Matrix3d Ri = itv.R_from.asEigen();
+            const Eigen::Matrix3d Rj = itv.R_to.asEigen();
+
+            const Eigen::Vector3d dbg = toEigen(bias_gyro_ - d.bias_gyro);
+            const Eigen::Vector3d dba = toEigen(bias_acc_ - d.bias_acc);
+
+            // ---- (a) gravity residual ------------------------------------
+            //   r = (v_j - v_i) - g*dt - R_i * dV_ij(b)
+            {
+                const double dt = d.deltaTij;
+
+                const Eigen::Vector3d dV =
+                    toEigen(d.deltaVij) + d.dV_dba.asEigen() * dba + d.dV_dbg.asEigen() * dbg;
+
+                const Eigen::Vector3d r =
+                    toEigen(itv.v_to) - toEigen(itv.v_from) - toEigen(gravity_) * dt - Ri * dV;
+
+                Eigen::Matrix3d Jg_ = -Eigen::Matrix3d::Identity() * dt;  // d/d gravity
+                Eigen::Matrix3d Ja  = -Ri * d.dV_dba.asEigen();
+                Eigen::Matrix3d Jb  = -Ri * d.dV_dbg.asEigen();
+
+                // Weight = preintegration velocity covariance (rotated into
+                // the map frame) PLUS both external velocity covariances.
+                // This is the "earned" sigma: never hand-tuned.
+                const Eigen::Matrix3d covDV = d.cov.asEigen().block<3, 3>(3, 3);
+                const Eigen::Matrix3d cov =
+                    Ri * covDV * Ri.transpose() + itv.cov_v_from.asEigen() + itv.cov_v_to.asEigen();
+
+                const Eigen::LLT<Eigen::Matrix3d> llt(
+                    cov + Eigen::Matrix3d::Identity() * NUMERIC_RIDGE);
+                const auto L = llt.matrixL();
+
+                Eigen::Vector3d rw = L.solve(r);
+                Jg_                = L.solve(Jg_);
+                Ja                 = L.solve(Ja);
+                Jb                 = L.solve(Jb);
+
+                // Huber: a bad odometry velocity or a jolt cannot drag the
+                // estimate.
+                const double rn = rw.norm();
+                if (rn > huberK)
+                {
+                    const double sqrtW = std::sqrt(huberK / rn);
+                    rw *= sqrtW;
+                    Jg_ *= sqrtW;
+                    Ja *= sqrtW;
+                    Jb *= sqrtW;
+                }
+
+                H.block<3, 3>(IDX_G, IDX_G) += Jg_.transpose() * Jg_;
+                H.block<3, 3>(IDX_G, IDX_BA) += Jg_.transpose() * Ja;
+                H.block<3, 3>(IDX_BA, IDX_G) += Ja.transpose() * Jg_;
+                H.block<3, 3>(IDX_G, IDX_BG) += Jg_.transpose() * Jb;
+                H.block<3, 3>(IDX_BG, IDX_G) += Jb.transpose() * Jg_;
+
+                H.block<3, 3>(IDX_BA, IDX_BA) += Ja.transpose() * Ja;
+                H.block<3, 3>(IDX_BG, IDX_BG) += Jb.transpose() * Jb;
+                H.block<3, 3>(IDX_BA, IDX_BG) += Ja.transpose() * Jb;
+                H.block<3, 3>(IDX_BG, IDX_BA) += Jb.transpose() * Ja;
+
+                b.segment<3>(IDX_G) += Jg_.transpose() * rw;
+                b.segment<3>(IDX_BA) += Ja.transpose() * rw;
+                b.segment<3>(IDX_BG) += Jb.transpose() * rw;
+            }
+
+            // ---- (b) relative-rotation residual (gyro bias) --------------
+            //   r = Log( dR_ij(b_g)^T * R_i^T * R_j )
+            {
+                const Eigen::Vector3d       Jdbg  = d.dR_dbg.asEigen() * dbg;
+                const mrpt::math::TVector3D JdbgV = fromEigen(Jdbg);
+                const Eigen::Matrix3d dRcorr      = d.deltaRij.asEigen() * so3_exp(JdbgV).asEigen();
+
+                SO3 M;
+                M.asEigen() = dRcorr.transpose() * Ri.transpose() * Rj;
+
+                const mrpt::math::TVector3D e     = so3_log(M);
+                const Eigen::Matrix3d       JrInv = inverse_right_jacobian_so3(e).asEigen();
+
+                Eigen::Matrix3d Jb = -JrInv * so3_exp(e * -1.0).asEigen() *
+                                     right_jacobian_so3(JdbgV).asEigen() * d.dR_dbg.asEigen();
+
+                // Weight: preintegrated rotation covariance PLUS the assumed
+                // uncertainty of the external odometry's relative rotation.
+                const Eigen::Matrix3d cov =
+                    d.cov.asEigen().block<3, 3>(0, 0) + Eigen::Matrix3d::Identity() * covOdomRot;
+
+                const Eigen::LLT<Eigen::Matrix3d> llt(
+                    cov + Eigen::Matrix3d::Identity() * NUMERIC_RIDGE);
+                const auto L = llt.matrixL();
+
+                const Eigen::Vector3d rw = L.solve(toEigen(e));
+                Jb                       = L.solve(Jb);
+
+                H.block<3, 3>(IDX_BG, IDX_BG) += Jb.transpose() * Jb;
+                b.segment<3>(IDX_BG) += Jb.transpose() * rw;
+            }
+        }
+
+        // ---- Gravity magnitude soft constraint ---------------------------
+        {
+            const double gn = gravity_.norm();
+            if (gn > DIRECTION_EPS)
+            {
+                const double             r = wMag * (gn - parameters.gravity_magnitude);
+                const Eigen::RowVector3d J = wMag * (toEigen(gravity_) / gn).transpose();
+
+                H.block<3, 3>(IDX_G, IDX_G) += J.transpose() * J;
+                b.segment<3>(IDX_G) += J.transpose() * r;
+            }
+        }
+
+        // ---- Zero-anchored bias priors -----------------------------------
+        {
+            const Eigen::Vector3d rg = wBg * toEigen(bias_gyro_ - bias_gyro_prior_);
+            const Eigen::Vector3d ra = wBa * toEigen(bias_acc_ - bias_acc_prior_);
+
+            H.block<3, 3>(IDX_BG, IDX_BG) += Eigen::Matrix3d::Identity() * (wBg * wBg);
+            H.block<3, 3>(IDX_BA, IDX_BA) += Eigen::Matrix3d::Identity() * (wBa * wBa);
+
+            b.segment<3>(IDX_BG) += wBg * rg;
+            b.segment<3>(IDX_BA) += wBa * ra;
+        }
+
+        // ---- Solve and update --------------------------------------------
+        H.diagonal().array() += NUMERIC_RIDGE;
+
+        const Eigen::LDLT<Eigen::Matrix<double, N, N>> ldlt(H);
+        if (ldlt.info() != Eigen::Success)
+        {
+            return false;
+        }
+        const Eigen::Matrix<double, N, 1> dx = ldlt.solve(-b);
+        if (!dx.allFinite())
+        {
+            return false;
+        }
+
+        gravity_   = gravity_ + fromEigen(dx.segment<3>(IDX_G));
+        bias_gyro_ = bias_gyro_ + fromEigen(dx.segment<3>(IDX_BG));
+        bias_acc_  = bias_acc_ + fromEigen(dx.segment<3>(IDX_BA));
+
+        iterationsDone = iter + 1;
+
+        if (dx.norm() < parameters.tolerance)
+        {
+            break;
+        }
+    }
+
+    // ---- Build the result -------------------------------------------------
+    Result res;
+    res.timestamp      = intervals_.back().t_to;
+    res.gravity_in_map = gravity_;
+    res.correction     = correction_from_gravity(gravity_);
+    res.bias_acc       = bias_acc_;
+    res.bias_gyro      = bias_gyro_;
+    res.num_intervals  = intervals_.size();
+    res.iterations     = iterationsDone;
+
+    std::tie(res.pitch_correction, res.roll_correction) = pitchRollOf(res.correction);
+    res.tilt                                            = so3_log(res.correction).norm();
+
+    // "Earned" sigmas: the marginal covariance of the gravity block, pushed
+    // through the numerical Jacobian of (pitch, roll) of the correction.
+    bool covOk = false;
+    {
+        const Eigen::LDLT<Eigen::Matrix<double, N, N>> ldlt(H);
+        if (ldlt.info() == Eigen::Success)
+        {
+            Eigen::Matrix<double, N, 3> sel = Eigen::Matrix<double, N, 3>::Zero();
+            sel.block<3, 3>(IDX_G, 0)       = Eigen::Matrix3d::Identity();
+
+            const Eigen::Matrix<double, N, 3> covCols = ldlt.solve(sel);
+            const Eigen::Matrix3d             covG    = covCols.block<3, 3>(IDX_G, 0);
+
+            if (covG.allFinite())
+            {
+                Eigen::Matrix<double, 2, 3> J   = Eigen::Matrix<double, 2, 3>::Zero();
+                const double                eps = 1e-6;
+                for (int i = 0; i < 3; i++)
+                {
+                    mrpt::math::TVector3D dg{0, 0, 0};
+                    dg[i] = eps;
+
+                    const auto [pp, rp] = pitchRollOf(correction_from_gravity(gravity_ + dg));
+                    const auto [pm, rm] = pitchRollOf(correction_from_gravity(gravity_ - dg));
+
+                    J(0, i) = (pp - pm) / (2 * eps);
+                    J(1, i) = (rp - rm) / (2 * eps);
+                }
+
+                const Eigen::Matrix2d covPR = J * covG * J.transpose();
+                if (covPR(0, 0) >= 0 && covPR(1, 1) >= 0)
+                {
+                    res.pitch_sigma = std::sqrt(covPR(0, 0));
+                    res.roll_sigma  = std::sqrt(covPR(1, 1));
+                    covOk           = true;
+                }
+            }
+        }
+    }
+
+    const double maxSigma = mrpt::DEG2RAD(parameters.max_tilt_sigma_deg);
+    res.converged = covOk && res.num_intervals >= parameters.min_intervals_for_convergence &&
+                    res.pitch_sigma < maxSigma && res.roll_sigma < maxSigma;
+
+    latest_result_ = res;
+    return true;
+}

--- a/src/so3_jacobians.cpp
+++ b/src/so3_jacobians.cpp
@@ -1,0 +1,114 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   so3_jacobians.cpp
+ * @brief  SO(3) right Jacobian and small helpers used by IMU preintegration.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ */
+
+#include <mola_imu_preintegration/so3_jacobians.h>
+#include <mrpt/poses/Lie/SO.h>
+
+#include <Eigen/Dense>
+#include <cmath>
+
+using namespace mola::imu;
+
+namespace
+{
+/// Below this rotation angle [rad] the closed forms suffer cancellation and a
+/// Taylor expansion is used instead. At this threshold the truncated terms are
+/// of order 1e-17, i.e. already below double precision.
+constexpr double SMALL_ANGLE_THRESHOLD = 1e-4;
+}  // namespace
+
+mrpt::math::CMatrixDouble33 mola::imu::skew_symmetric(const mrpt::math::TVector3D& v)
+{
+    mrpt::math::CMatrixDouble33 K;
+    K(0, 0) = 0;
+    K(0, 1) = -v.z;
+    K(0, 2) = v.y;
+    K(1, 0) = v.z;
+    K(1, 1) = 0;
+    K(1, 2) = -v.x;
+    K(2, 0) = -v.y;
+    K(2, 1) = v.x;
+    K(2, 2) = 0;
+    return K;
+}
+
+SO3 mola::imu::so3_exp(const mrpt::math::TVector3D& phi)
+{
+    return mrpt::poses::Lie::SO<3>::exp(mrpt::math::CVectorFixedDouble<3>(phi));
+}
+
+mrpt::math::TVector3D mola::imu::so3_log(const SO3& R)
+{
+    const auto v = mrpt::poses::Lie::SO<3>::log(R);
+    return {v[0], v[1], v[2]};
+}
+
+mrpt::math::CMatrixDouble33 mola::imu::right_jacobian_so3(const mrpt::math::TVector3D& phi)
+{
+    const double t2 = phi.sqrNorm();
+    const double t  = std::sqrt(t2);
+
+    // Coefficients of  Jr = I - c1 * K + c2 * K^2
+    double c1 = 0;
+    double c2 = 0;
+    if (t < SMALL_ANGLE_THRESHOLD)
+    {
+        // (1-cos t)/t^2  and  (t - sin t)/t^3
+        c1 = 0.5 - t2 / 24.0;
+        c2 = 1.0 / 6.0 - t2 / 120.0;
+    }
+    else
+    {
+        c1 = (1.0 - std::cos(t)) / t2;
+        c2 = (t - std::sin(t)) / (t2 * t);
+    }
+
+    const auto K  = skew_symmetric(phi);
+    const auto Ke = K.asEigen();
+
+    mrpt::math::CMatrixDouble33 Jr;
+    Jr.asEigen() = Eigen::Matrix3d::Identity() - c1 * Ke + c2 * (Ke * Ke);
+    return Jr;
+}
+
+mrpt::math::CMatrixDouble33 mola::imu::inverse_right_jacobian_so3(const mrpt::math::TVector3D& phi)
+{
+    const double t2 = phi.sqrNorm();
+    const double t  = std::sqrt(t2);
+
+    // Coefficient of K^2 in  Jr^-1 = I + K/2 + c * K^2
+    double c = 0;
+    if (t < SMALL_ANGLE_THRESHOLD)
+    {
+        c = 1.0 / 12.0 + t2 / 720.0;
+    }
+    else
+    {
+        c = 1.0 / t2 - (1.0 + std::cos(t)) / (2.0 * t * std::sin(t));
+    }
+
+    const auto K  = skew_symmetric(phi);
+    const auto Ke = K.asEigen();
+
+    mrpt::math::CMatrixDouble33 Jinv;
+    Jinv.asEigen() = Eigen::Matrix3d::Identity() + 0.5 * Ke + c * (Ke * Ke);
+    return Jinv;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,3 +33,24 @@ mola_add_test(
   LINK_LIBRARIES
     mola::mola_imu_preintegration
 )
+
+mola_add_test(
+  TARGET  test-so3-jacobians
+  SOURCES test-so3-jacobians.cpp
+  LINK_LIBRARIES
+    mola::mola_imu_preintegration
+)
+
+mola_add_test(
+  TARGET  test-imu-preintegrator
+  SOURCES test-imu-preintegrator.cpp
+  LINK_LIBRARIES
+    mola::mola_imu_preintegration
+)
+
+mola_add_test(
+  TARGET  test-map-gravity-estimator
+  SOURCES test-map-gravity-estimator.cpp
+  LINK_LIBRARIES
+    mola::mola_imu_preintegration
+)

--- a/tests/test-imu-preintegrator.cpp
+++ b/tests/test-imu-preintegrator.cpp
@@ -1,0 +1,523 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   test-imu-preintegrator.cpp
+ * @brief  Unit tests for full on-manifold IMU preintegration.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ *
+ * The reference is a synthetic trajectory whose true pose/velocity is known in
+ * closed form. The IMU readings are SYNTHESIZED from it, so the preintegrated
+ * deltas are compared against the exact analytic answer, not against a second
+ * implementation of the same equations.
+ */
+
+#include <mola_imu_preintegration/ImuPreintegrator.h>
+#include <mrpt/core/exceptions.h>
+
+#include <Eigen/Dense>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <vector>
+
+using namespace mola::imu;
+using mrpt::math::TVector3D;
+
+namespace
+{
+constexpr double GRAVITY = 9.81;
+
+/// A synthetic ground-truth trajectory: position, velocity and attitude as
+/// analytic functions of time, plus the IMU readings they imply.
+struct SyntheticTrajectory
+{
+    TVector3D omega{0.35, -0.20, 0.55};  //!< constant body angular rate [rad/s]
+    TVector3D tilt0{0.08, -0.05, 0.0};  //!< initial attitude, as a rotation vector
+
+    /// Position follows a Lissajous curve, so acceleration is nontrivial in
+    /// all three axes.
+    TVector3D amplitude{2.0, 1.5, 0.6};
+    TVector3D frequency{0.7, 1.1, 1.7};  //!< [rad/s]
+
+    SO3 R(double t) const
+    {
+        SO3 out;
+        out.asEigen() = so3_exp(tilt0).asEigen() * so3_exp(omega * t).asEigen();
+        return out;
+    }
+
+    TVector3D p(double t) const
+    {
+        return {
+            amplitude.x * std::sin(frequency.x * t), amplitude.y * std::sin(frequency.y * t),
+            amplitude.z * std::sin(frequency.z * t)};
+    }
+
+    TVector3D v(double t) const
+    {
+        return {
+            amplitude.x * frequency.x * std::cos(frequency.x * t),
+            amplitude.y * frequency.y * std::cos(frequency.y * t),
+            amplitude.z * frequency.z * std::cos(frequency.z * t)};
+    }
+
+    /// World-frame coordinate acceleration.
+    TVector3D a_world(double t) const
+    {
+        return {
+            -amplitude.x * frequency.x * frequency.x * std::sin(frequency.x * t),
+            -amplitude.y * frequency.y * frequency.y * std::sin(frequency.y * t),
+            -amplitude.z * frequency.z * frequency.z * std::sin(frequency.z * t)};
+    }
+
+    /// What an ideal accelerometer reads: the proper acceleration (specific
+    /// force) in the body frame, i.e. R^T (a_world - g).
+    TVector3D accel_reading(double t) const
+    {
+        const TVector3D       aw = a_world(t);
+        const Eigen::Vector3d d(aw.x, aw.y, aw.z + GRAVITY);
+        const Eigen::Vector3d b = R(t).asEigen().transpose() * d;
+        return {b.x(), b.y(), b.z()};
+    }
+
+    /// What an ideal gyroscope reads: the body-frame angular rate (constant).
+    TVector3D gyro_reading(double /*t*/) const { return omega; }
+};
+
+/// Feeds the trajectory's readings into a preintegrator over [t0, t1].
+void integrate(
+    ImuPreintegrator& pim, const SyntheticTrajectory& traj, double t0, double t1, double dt,
+    const TVector3D& biasAcc = {0, 0, 0}, const TVector3D& biasGyro = {0, 0, 0})
+{
+    const int n = static_cast<int>(std::llround((t1 - t0) / dt));
+    for (int k = 0; k < n; k++)
+    {
+        // Sample at the START of each step, matching the integrator's own
+        // convention (a reading is held constant over the FOLLOWING dt).
+        // Sampling elsewhere would measure the mismatch between the two
+        // conventions rather than the integrator's own accuracy.
+        const double t = t0 + k * dt;
+        pim.integrate_measurement(
+            traj.accel_reading(t) + biasAcc, traj.gyro_reading(t) + biasGyro, dt);
+    }
+}
+
+struct ExactDeltas
+{
+    SO3       dR;
+    TVector3D dV;
+    TVector3D dP;
+};
+
+/// The exact deltas implied by the trajectory definition.
+ExactDeltas exactDeltas(const SyntheticTrajectory& traj, double t0, double t1)
+{
+    const double    dt = t1 - t0;
+    const TVector3D g{0, 0, -GRAVITY};
+
+    const Eigen::Matrix3d Ri = traj.R(t0).asEigen();
+
+    ExactDeltas out;
+    out.dR.asEigen() = Ri.transpose() * traj.R(t1).asEigen();
+
+    const TVector3D vi = traj.v(t0);
+    const TVector3D dv = traj.v(t1) - vi - g * dt;
+    const TVector3D dp = traj.p(t1) - traj.p(t0) - vi * dt - g * (0.5 * dt * dt);
+
+    const Eigen::Vector3d dve = Ri.transpose() * Eigen::Vector3d(dv.x, dv.y, dv.z);
+    const Eigen::Vector3d dpe = Ri.transpose() * Eigen::Vector3d(dp.x, dp.y, dp.z);
+
+    out.dV = {dve.x(), dve.y(), dve.z()};
+    out.dP = {dpe.x(), dpe.y(), dpe.z()};
+    return out;
+}
+
+double rotationErrorDeg(const SO3& a, const SO3& b)
+{
+    SO3 d;
+    d.asEigen() = a.asEigen().transpose() * b.asEigen();
+    return mrpt::RAD2DEG(so3_log(d).norm());
+}
+
+// -----------------------------------------------------------------------
+// The gold-standard test: deltas must match the analytic answer.
+// -----------------------------------------------------------------------
+void test_matches_analytic_trajectory()
+{
+    const SyntheticTrajectory traj;
+    const double              t0 = 0.0;
+    const double              t1 = 2.5;
+
+    ImuPreintegrator pim;
+    pim.reset_integration();
+    integrate(pim, traj, t0, t1, 1.0 / 400.0);
+
+    const auto& st = pim.current_state();
+    const auto  ex = exactDeltas(traj, t0, t1);
+
+    ASSERT_NEAR_(st.deltaTij, t1 - t0, 1e-9);
+    ASSERT_GT_(st.num_measurements, 900U);
+
+    // Rotation is exact here regardless of dt: the gyro rate is constant, so
+    // composing Exp(w*dt) reproduces Exp(w*T) exactly.
+    const double rotErr = rotationErrorDeg(st.deltaRij, ex.dR);
+    ASSERTMSG_(rotErr < 1e-3, mrpt::format("deltaR error too large: %g deg", rotErr));
+
+    // Velocity/position carry the first-order discretization error inherent to
+    // the standard Euler-forward preintegration form (see the class docs). At
+    // 400 Hz over 2.5 s of aggressive motion that is a few cm/s; the
+    // convergence test below is what pins down the error ORDER.
+    const double velErr = (st.deltaVij - ex.dV).norm();
+    const double posErr = (st.deltaPij - ex.dP).norm();
+    ASSERTMSG_(velErr < 0.05, mrpt::format("deltaV error too large: %g m/s", velErr));
+    ASSERTMSG_(posErr < 0.05, mrpt::format("deltaP error too large: %g m", posErr));
+
+    std::cout << "test_matches_analytic_trajectory passed (rot err " << rotErr << " deg)."
+              << std::endl;
+}
+
+// Discretization error must shrink as the sample rate grows: this catches an
+// integration scheme that is biased rather than merely noisy.
+void test_converges_with_sample_rate()
+{
+    const SyntheticTrajectory traj;
+    const auto                ex = exactDeltas(traj, 0.0, 1.0);
+
+    // Each rate is 4x the previous one. A first-order scheme must therefore
+    // shrink the error by ~4x per step: asserting the RATIO (not just "it got
+    // smaller") is what actually pins down the convergence order and would
+    // catch a scheme that is accidentally zeroth-order in some term.
+    double prevErr = std::numeric_limits<double>::max();
+    for (const double rate : {50.0, 200.0, 800.0})
+    {
+        ImuPreintegrator pim;
+        pim.reset_integration();
+        integrate(pim, traj, 0.0, 1.0, 1.0 / rate);
+
+        const double err = (pim.current_state().deltaVij - ex.dV).norm();
+        if (prevErr != std::numeric_limits<double>::max())
+        {
+            const double ratio = prevErr / err;
+            ASSERTMSG_(
+                ratio > 3.0,
+                mrpt::format(
+                    "convergence slower than first order at rate=%g Hz: ratio=%g (%g -> %g)", rate,
+                    ratio, prevErr, err));
+        }
+        prevErr = err;
+    }
+    ASSERT_LT_(prevErr, 0.02);
+
+    std::cout << "test_converges_with_sample_rate passed (err at 800 Hz: " << prevErr << ")."
+              << std::endl;
+}
+
+// -----------------------------------------------------------------------
+// First-order bias update vs. full re-integration at the perturbed bias.
+// -----------------------------------------------------------------------
+void test_bias_correction_matches_reintegration()
+{
+    const SyntheticTrajectory traj;
+    const double              t0 = 0.0;
+    const double              t1 = 1.5;
+    const double              dt = 1.0 / 400.0;
+
+    // A realistic bias perturbation away from the linearization point:
+    const TVector3D dba{0.02, -0.03, 0.01};  // m/s^2
+    const TVector3D dbg{0.002, 0.001, -0.003};  // rad/s
+
+    // (a) integrate at zero bias, then apply the first-order correction:
+    ImuPreintegrator pimA;
+    pimA.reset_integration({0, 0, 0}, {0, 0, 0});
+    integrate(pimA, traj, t0, t1, dt);
+    const auto corrected = pimA.current_state().bias_corrected(dba, dbg);
+
+    // (b) re-integrate from scratch with the perturbed bias as linearization
+    //     point (the readings are identical; only the subtracted bias differs):
+    ImuPreintegrator pimB;
+    pimB.reset_integration(dba, dbg);
+    integrate(pimB, traj, t0, t1, dt);
+    const auto& exact = pimB.current_state();
+
+    const double uncorrectedRotErr =
+        rotationErrorDeg(pimA.current_state().deltaRij, exact.deltaRij);
+    const double correctedRotErr = rotationErrorDeg(corrected.deltaRij, exact.deltaRij);
+
+    ASSERT_GT_(uncorrectedRotErr, 0.1);
+    ASSERTMSG_(
+        correctedRotErr < 0.02 * uncorrectedRotErr,
+        mrpt::format(
+            "first-order rotation correction too weak: uncorrected=%g deg corrected=%g deg",
+            uncorrectedRotErr, correctedRotErr));
+
+    const double uncorrectedVelErr = (pimA.current_state().deltaVij - exact.deltaVij).norm();
+    const double correctedVelErr   = (corrected.deltaVij - exact.deltaVij).norm();
+
+    ASSERT_GT_(uncorrectedVelErr, 0.01);
+    ASSERTMSG_(
+        correctedVelErr < 0.05 * uncorrectedVelErr,
+        mrpt::format(
+            "first-order velocity correction too weak: uncorrected=%g corrected=%g",
+            uncorrectedVelErr, correctedVelErr));
+
+    std::cout << "test_bias_correction_matches_reintegration passed (rot " << uncorrectedRotErr
+              << " -> " << correctedRotErr << " deg)." << std::endl;
+}
+
+// -----------------------------------------------------------------------
+// Bias Jacobians vs. numerical differentiation of a full re-integration.
+// -----------------------------------------------------------------------
+void test_bias_jacobians_match_numerical()
+{
+    const SyntheticTrajectory traj;
+    const double              t0  = 0.0;
+    const double              t1  = 1.0;
+    const double              dt  = 1.0 / 400.0;
+    const double              eps = 1e-6;
+
+    ImuPreintegrator pim;
+    pim.reset_integration();
+    integrate(pim, traj, t0, t1, dt);
+    const auto& st = pim.current_state();
+
+    const auto reintegrate = [&](const TVector3D& ba, const TVector3D& bg)
+    {
+        ImuPreintegrator p;
+        p.reset_integration(ba, bg);
+        integrate(p, traj, t0, t1, dt);
+        return p.current_state();
+    };
+
+    for (int i = 0; i < 3; i++)
+    {
+        TVector3D db{0, 0, 0};
+        db[i] = eps;
+
+        // --- accel bias: affects dV and dP only ---
+        {
+            const auto plus  = reintegrate(db, {0, 0, 0});
+            const auto minus = reintegrate(db * -1.0, {0, 0, 0});
+
+            const TVector3D numV = (plus.deltaVij - minus.deltaVij) * (1.0 / (2 * eps));
+            const TVector3D numP = (plus.deltaPij - minus.deltaPij) * (1.0 / (2 * eps));
+
+            for (int r = 0; r < 3; r++)
+            {
+                ASSERT_NEAR_(st.dV_dba(r, i), numV[r], 1e-6);
+                ASSERT_NEAR_(st.dP_dba(r, i), numP[r], 1e-6);
+            }
+        }
+
+        // --- gyro bias: affects dR, dV and dP ---
+        {
+            const auto plus  = reintegrate({0, 0, 0}, db);
+            const auto minus = reintegrate({0, 0, 0}, db * -1.0);
+
+            // dR_dbg is defined on the manifold: dR(b) = dR_bar * Exp(J * db),
+            // so its numerical counterpart is Log(dR_bar^T dR(b)) / db.
+            SO3 relPlus;
+            SO3 relMinus;
+            relPlus.asEigen()  = st.deltaRij.asEigen().transpose() * plus.deltaRij.asEigen();
+            relMinus.asEigen() = st.deltaRij.asEigen().transpose() * minus.deltaRij.asEigen();
+
+            const TVector3D numR = (so3_log(relPlus) - so3_log(relMinus)) * (1.0 / (2 * eps));
+            const TVector3D numV = (plus.deltaVij - minus.deltaVij) * (1.0 / (2 * eps));
+            const TVector3D numP = (plus.deltaPij - minus.deltaPij) * (1.0 / (2 * eps));
+
+            for (int r = 0; r < 3; r++)
+            {
+                ASSERT_NEAR_(st.dR_dbg(r, i), numR[r], 1e-5);
+                ASSERT_NEAR_(st.dV_dbg(r, i), numV[r], 1e-4);
+                ASSERT_NEAR_(st.dP_dbg(r, i), numP[r], 1e-4);
+            }
+        }
+    }
+
+    std::cout << "test_bias_jacobians_match_numerical passed." << std::endl;
+}
+
+// -----------------------------------------------------------------------
+// Covariance propagation vs. Monte Carlo.
+// -----------------------------------------------------------------------
+void test_covariance_matches_monte_carlo()
+{
+    const SyntheticTrajectory traj;
+    const double              t0 = 0.0;
+    const double              t1 = 0.5;
+    const double              dt = 1.0 / 200.0;
+
+    // Noise densities (sigma units: rad/s/sqrt(Hz) and m/s^2/sqrt(Hz)):
+    const double sigmaG = 5e-3;
+    const double sigmaA = 5e-2;
+
+    ImuIntegrationParams params;
+    params.cov_gyro.setDiagonal(sigmaG * sigmaG);
+    params.cov_acc.setDiagonal(sigmaA * sigmaA);
+
+    // Analytic propagation:
+    ImuPreintegrator pim(params);
+    pim.reset_integration();
+    integrate(pim, traj, t0, t1, dt);
+    const auto& st = pim.current_state();
+
+    // Monte Carlo: the per-sample discrete noise stddev is density/sqrt(dt).
+    const double                     sG = sigmaG / std::sqrt(dt);
+    const double                     sA = sigmaA / std::sqrt(dt);
+    std::mt19937                     rng(42);
+    std::normal_distribution<double> nd(0.0, 1.0);
+
+    const int       N         = 400;
+    Eigen::MatrixXd empirical = Eigen::MatrixXd::Zero(9, 9);
+
+    for (int trial = 0; trial < N; trial++)
+    {
+        ImuPreintegrator p(params);
+        p.reset_integration();
+
+        const int n = static_cast<int>(std::llround((t1 - t0) / dt));
+        for (int k = 0; k < n; k++)
+        {
+            const double    t = t0 + (k + 0.5) * dt;
+            const TVector3D na{nd(rng) * sA, nd(rng) * sA, nd(rng) * sA};
+            const TVector3D ng{nd(rng) * sG, nd(rng) * sG, nd(rng) * sG};
+            p.integrate_measurement(traj.accel_reading(t) + na, traj.gyro_reading(t) + ng, dt);
+        }
+
+        // Error w.r.t. the noise-free result, in the same [theta, v, p] order.
+        SO3 dRerr;
+        dRerr.asEigen() = st.deltaRij.asEigen().transpose() * p.current_state().deltaRij.asEigen();
+        const TVector3D th = so3_log(dRerr);
+        const TVector3D dv = p.current_state().deltaVij - st.deltaVij;
+        const TVector3D dp = p.current_state().deltaPij - st.deltaPij;
+
+        Eigen::VectorXd e(9);
+        e << th.x, th.y, th.z, dv.x, dv.y, dv.z, dp.x, dp.y, dp.z;
+        empirical += e * e.transpose();
+    }
+    empirical /= static_cast<double>(N);
+
+    // Compare the diagonal standard deviations. With N=400 the sampling error
+    // of a stddev is ~1/sqrt(2N) ~ 3.5%, so a 25% band is a meaningful test
+    // (it catches wrong scaling, wrong dt powers or a missing term) while
+    // staying robust to Monte-Carlo noise.
+    for (int i = 0; i < 9; i++)
+    {
+        const double sAna = std::sqrt(st.cov(i, i));
+        const double sEmp = std::sqrt(empirical(i, i));
+        ASSERT_GT_(sAna, 0.0);
+        ASSERTMSG_(
+            std::abs(sEmp / sAna - 1.0) < 0.25,
+            mrpt::format(
+                "covariance mismatch at index %i: analytic sigma=%g empirical=%g", i, sAna, sEmp));
+    }
+
+    std::cout << "test_covariance_matches_monte_carlo passed." << std::endl;
+}
+
+// -----------------------------------------------------------------------
+// Degenerate / guard cases.
+// -----------------------------------------------------------------------
+void test_rejects_non_positive_dt()
+{
+    ImuPreintegrator pim;
+    pim.reset_integration();
+
+    bool threwOnZero = false;
+    try
+    {
+        pim.integrate_measurement({0, 0, GRAVITY}, {0, 0, 0}, 0.0);
+    }
+    catch (const std::exception&)
+    {
+        threwOnZero = true;
+    }
+    ASSERT_(threwOnZero);
+
+    bool threwOnNegative = false;
+    try
+    {
+        pim.integrate_measurement({0, 0, GRAVITY}, {0, 0, 0}, -0.01);
+    }
+    catch (const std::exception&)
+    {
+        threwOnNegative = true;
+    }
+    ASSERT_(threwOnNegative);
+
+    std::cout << "test_rejects_non_positive_dt passed." << std::endl;
+}
+
+void test_reset_clears_state()
+{
+    ImuPreintegrator pim;
+    pim.reset_integration();
+    pim.integrate_measurement({0.1, 0.2, 9.7}, {0.01, 0.02, 0.03}, 0.01);
+    ASSERT_GT_(pim.current_state().deltaTij, 0);
+
+    pim.reset_integration();
+    ASSERT_EQUAL_(pim.current_state().deltaTij, 0);
+    ASSERT_EQUAL_(pim.current_state().num_measurements, 0U);
+    ASSERT_LT_(pim.current_state().deltaVij.norm(), 1e-15);
+    ASSERT_LT_(pim.current_state().cov.asEigen().cwiseAbs().maxCoeff(), 1e-15);
+
+    std::cout << "test_reset_clears_state passed." << std::endl;
+}
+
+void test_stationary_level_sensor_reads_gravity_only()
+{
+    // At rest and level, the accelerometer reads (0,0,+g). The preintegrated
+    // dV must then be exactly +g*dt in the body frame, since the delta
+    // definition has gravity subtracted OUTSIDE the integration.
+    ImuPreintegrator pim;
+    pim.reset_integration();
+
+    const double dt = 0.005;
+    for (int i = 0; i < 200; i++)
+    {
+        pim.integrate_measurement({0, 0, GRAVITY}, {0, 0, 0}, dt);
+    }
+
+    const auto& st = pim.current_state();
+    ASSERT_NEAR_(st.deltaTij, 1.0, 1e-12);
+    ASSERT_LT_(rotationErrorDeg(st.deltaRij, SO3::Identity()), 1e-12);
+    ASSERT_NEAR_(st.deltaVij.x, 0.0, 1e-12);
+    ASSERT_NEAR_(st.deltaVij.y, 0.0, 1e-12);
+    ASSERT_NEAR_(st.deltaVij.z, GRAVITY, 1e-12);
+
+    std::cout << "test_stationary_level_sensor_reads_gravity_only passed." << std::endl;
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_matches_analytic_trajectory();
+        test_converges_with_sample_rate();
+        test_bias_correction_matches_reintegration();
+        test_bias_jacobians_match_numerical();
+        test_covariance_matches_monte_carlo();
+        test_rejects_non_positive_dt();
+        test_reset_clears_state();
+        test_stationary_level_sensor_reads_gravity_only();
+        std::cout << "All ImuPreintegrator tests passed." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/tests/test-map-gravity-estimator.cpp
+++ b/tests/test-map-gravity-estimator.cpp
@@ -132,20 +132,6 @@ struct SyntheticWorld
     static Eigen::Vector3d toE(const TVector3D& v) { return {v.x, v.y, v.z}; }
 };
 
-/** Noise densities of a typical MEMS IMU (sigma units: rad/s/sqrt(Hz) and
- *  m/s^2/sqrt(Hz)). NOTE: ImuIntegrationParams defaults to IDENTITY
- *  covariances, i.e. sigma=1 for both, which is ~1000x worse than any real
- *  sensor; using that here would make every "earned" sigma so large that the
- *  estimator would rightly never report convergence.
- */
-ImuIntegrationParams realisticImuParams()
-{
-    ImuIntegrationParams p;
-    p.cov_gyro.setDiagonal(mrpt::square(3e-3));
-    p.cov_acc.setDiagonal(mrpt::square(3e-2));
-    return p;
-}
-
 /// Builds one interval of the given duration, preintegrating at `rate` Hz.
 MapGravityEstimator::Interval makeInterval(
     const SyntheticWorld& w, double t0, double t1, double rate,
@@ -227,7 +213,7 @@ void test_recovers_map_tilt_while_always_moving()
     w.map_tilt = {mrpt::DEG2RAD(2.5), mrpt::DEG2RAD(-1.8), 0.0};  // ~3.1 deg of tilt
 
     MapGravityEstimator est;
-    const auto          res = runSequence(est, w, realisticImuParams(), 20);
+    const auto          res = runSequence(est, w, ImuIntegrationParams(), 20);
 
     const double dirErrDeg = angleBetweenDeg(res.gravity_in_map, w.gravity_in_map());
 
@@ -260,7 +246,7 @@ void test_level_map_yields_no_correction()
     SyntheticWorld w;  // map_tilt = 0
 
     MapGravityEstimator est;
-    const auto          res = runSequence(est, w, realisticImuParams(), 20);
+    const auto          res = runSequence(est, w, ImuIntegrationParams(), 20);
 
     ASSERTMSG_(
         mrpt::RAD2DEG(res.tilt) < 0.05,
@@ -286,7 +272,7 @@ void test_gyro_bias_observability()
         MapGravityEstimator est;
         est.parameters.bias_gyro_prior_sigma = 1.0;  // effectively no prior
 
-        const auto   res = runSequence(est, w, realisticImuParams(), 20);
+        const auto   res = runSequence(est, w, ImuIntegrationParams(), 20);
         const double err = (res.bias_gyro - w.bias_gyro).norm();
 
         ASSERTMSG_(
@@ -304,7 +290,7 @@ void test_gyro_bias_observability()
     //     It must still recover most of the true bias, and must not overshoot.
     {
         MapGravityEstimator est;
-        const auto          res = runSequence(est, w, realisticImuParams(), 20);
+        const auto          res = runSequence(est, w, ImuIntegrationParams(), 20);
 
         const double trueNorm = w.bias_gyro.norm();
         const double recovered =
@@ -344,7 +330,7 @@ void test_accel_bias_observability_with_rotation_excitation()
         MapGravityEstimator est;
         est.parameters.bias_acc_prior_sigma = 10.0;  // effectively no prior
 
-        const auto   res = runSequence(est, w, realisticImuParams(), 30);
+        const auto   res = runSequence(est, w, ImuIntegrationParams(), 30);
         const double err = (res.bias_acc - w.bias_acc).norm();
 
         // The floor here is the first-order discretization error of the
@@ -370,7 +356,7 @@ void test_accel_bias_observability_with_rotation_excitation()
     //     the RIGHT WAY and stays bounded, and that the tilt is still right.
     {
         MapGravityEstimator est;
-        const auto          res = runSequence(est, w, realisticImuParams(), 30);
+        const auto          res = runSequence(est, w, ImuIntegrationParams(), 30);
 
         const double trueNorm  = w.bias_acc.norm();
         const double recovered = (res.bias_acc.x * w.bias_acc.x + res.bias_acc.y * w.bias_acc.y +
@@ -406,7 +392,7 @@ void test_no_rotation_excitation_degrades_gracefully()
     w.body_tilt = {0, 0, 0};  // and level body
 
     MapGravityEstimator est;
-    const auto          res = runSequence(est, w, realisticImuParams(), 20);
+    const auto          res = runSequence(est, w, ImuIntegrationParams(), 20);
 
     ASSERT_(std::isfinite(res.tilt));
     ASSERT_(std::isfinite(res.bias_acc.norm()));
@@ -430,14 +416,14 @@ void test_huber_rejects_corrupted_velocity()
 
     // Reference run, all intervals clean:
     MapGravityEstimator estClean;
-    const auto          clean = runSequence(estClean, w, realisticImuParams(), 20);
+    const auto          clean = runSequence(estClean, w, ImuIntegrationParams(), 20);
 
     // Same, but one interval has a grossly wrong odometry velocity:
     MapGravityEstimator est;
     for (int k = 0; k < 20; k++)
     {
         const double t0  = k * 0.5;
-        auto         itv = makeInterval(w, t0, t0 + 0.5, 200.0, realisticImuParams());
+        auto         itv = makeInterval(w, t0, t0 + 0.5, 200.0, ImuIntegrationParams());
         if (k == 10)
         {
             itv.v_to = itv.v_to + TVector3D{5.0, -4.0, 3.0};  // a badly wrong LO velocity
@@ -499,7 +485,7 @@ void test_coverage_guard_rejects_truncated_window()
 
     // An interval whose samples only cover the first half of it: exactly the
     // failure that silently corrupts a preintegrated constraint.
-    auto itv = makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams());
+    auto itv = makeInterval(w, 0.0, 0.5, 200.0, ImuIntegrationParams());
     itv.t_to = itv.t_from + 1.0;  // claim twice the duration actually integrated
 
     ASSERT_(!est.add_interval(itv));
@@ -525,20 +511,20 @@ void test_input_guards()
     }
     // Non-positive duration:
     {
-        auto itv = makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams());
+        auto itv = makeInterval(w, 0.0, 0.5, 200.0, ImuIntegrationParams());
         itv.t_to = itv.t_from;
         ASSERT_(!est.add_interval(itv));
     }
     // Non-finite velocity:
     {
-        auto itv   = makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams());
+        auto itv   = makeInterval(w, 0.0, 0.5, 200.0, ImuIntegrationParams());
         itv.v_to.x = std::numeric_limits<double>::quiet_NaN();
         ASSERT_(!est.add_interval(itv));
     }
     // Out-of-order:
     {
-        ASSERT_(est.add_interval(makeInterval(w, 1.0, 1.5, 200.0, realisticImuParams())));
-        ASSERT_(!est.add_interval(makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams())));
+        ASSERT_(est.add_interval(makeInterval(w, 1.0, 1.5, 200.0, ImuIntegrationParams())));
+        ASSERT_(!est.add_interval(makeInterval(w, 0.0, 0.5, 200.0, ImuIntegrationParams())));
     }
 
     // Solving with a single interval must not crash (it is simply weak):
@@ -559,7 +545,7 @@ void test_window_slides_and_resets()
     for (int k = 0; k < 12; k++)
     {
         const double t0 = k * 0.5;
-        ASSERT_(est.add_interval(makeInterval(w, t0, t0 + 0.5, 200.0, realisticImuParams())));
+        ASSERT_(est.add_interval(makeInterval(w, t0, t0 + 0.5, 200.0, ImuIntegrationParams())));
     }
     ASSERT_EQUAL_(est.window_length(), 5U);
 

--- a/tests/test-map-gravity-estimator.cpp
+++ b/tests/test-map-gravity-estimator.cpp
@@ -1,0 +1,630 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   test-map-gravity-estimator.cpp
+ * @brief  Unit tests for MapGravityEstimator.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ *
+ * The central case is the one that motivates the whole feature: a map frame
+ * that has accumulated a tilt, on a trajectory that NEVER STOPS, with a raw
+ * accel+gyro IMU and no absolute attitude reference. Averaging accelerometer
+ * samples cannot recover the tilt there; preintegration can.
+ */
+
+#include <mola_imu_preintegration/MapGravityEstimator.h>
+#include <mrpt/core/exceptions.h>
+
+#include <Eigen/Dense>
+#include <cmath>
+#include <iostream>
+#include <random>
+
+using namespace mola::imu;
+using mrpt::math::TVector3D;
+
+namespace
+{
+constexpr double GRAVITY = 9.81;
+
+/** A synthetic world.
+ *
+ *  Ground truth lives in a gravity-aligned frame {W}. The odometry ("map")
+ *  frame {M} is {W} rotated by a fixed tilt, which is what the estimator has
+ *  to discover: everything the estimator is fed (attitudes, velocities) is
+ *  expressed in {M}, while the IMU of course senses true gravity.
+ */
+struct SyntheticWorld
+{
+    /// The tilt of the map frame: R_M_W, i.e. p_M = R_map_from_world * p_W.
+    TVector3D map_tilt{0, 0, 0};  //!< rotation vector [rad]
+
+    /// Body attitude in {W}: a constant tilt plus a steady yaw rotation, so
+    /// there IS rotation excitation (needed for accel-bias observability).
+    TVector3D body_tilt{0.05, 0.09, 0.0};
+    double    yaw_rate = 0.30;  //!< [rad/s]
+
+    /// Trajectory in {W}: a Lissajous curve, so the vehicle never stops and
+    /// acceleration is nontrivial in all axes.
+    TVector3D amplitude{3.0, 2.0, 0.5};
+    TVector3D frequency{0.6, 0.9, 1.4};
+
+    /// True IMU biases, in the body frame.
+    TVector3D bias_acc{0, 0, 0};
+    TVector3D bias_gyro{0, 0, 0};
+
+    SO3 R_map_from_world() const { return so3_exp(map_tilt); }
+
+    /// True body attitude in {W}.
+    SO3 R_world_body(double t) const
+    {
+        SO3 out;
+        out.asEigen() = so3_exp(body_tilt).asEigen() * so3_exp({0, 0, yaw_rate * t}).asEigen();
+        return out;
+    }
+
+    /// Body attitude as the odometry reports it, i.e. in {M}.
+    SO3 R_map_body(double t) const
+    {
+        SO3 out;
+        out.asEigen() = R_map_from_world().asEigen() * R_world_body(t).asEigen();
+        return out;
+    }
+
+    TVector3D v_world(double t) const
+    {
+        return {
+            amplitude.x * frequency.x * std::cos(frequency.x * t),
+            amplitude.y * frequency.y * std::cos(frequency.y * t),
+            amplitude.z * frequency.z * std::cos(frequency.z * t)};
+    }
+
+    /// Velocity as the odometry reports it, i.e. in {M}.
+    TVector3D v_map(double t) const
+    {
+        const Eigen::Vector3d v = R_map_from_world().asEigen() * toE(v_world(t));
+        return {v.x(), v.y(), v.z()};
+    }
+
+    TVector3D a_world(double t) const
+    {
+        return {
+            -amplitude.x * frequency.x * frequency.x * std::sin(frequency.x * t),
+            -amplitude.y * frequency.y * frequency.y * std::sin(frequency.y * t),
+            -amplitude.z * frequency.z * frequency.z * std::sin(frequency.z * t)};
+    }
+
+    /// Ideal accelerometer reading (proper acceleration in body frame), plus
+    /// the true bias.
+    TVector3D accel_reading(double t) const
+    {
+        const TVector3D       aw = a_world(t);
+        const Eigen::Vector3d d(aw.x, aw.y, aw.z + GRAVITY);
+        const Eigen::Vector3d b = R_world_body(t).asEigen().transpose() * d;
+        return TVector3D{b.x(), b.y(), b.z()} + bias_acc;
+    }
+
+    /// Ideal gyroscope reading, plus the true bias.
+    /// With `R(t) = Exp(body_tilt) * Rz(yaw_rate*t)`, we have
+    /// `R^T dR/dt = [ (0,0,yaw_rate) ]_x` exactly, i.e. the body-frame angular
+    /// rate is constant and equal to (0,0,yaw_rate), independently of the
+    /// constant tilt. (Rotating a world-frame rate into the body instead would
+    /// make the synthetic gyro inconsistent with the synthetic attitude.)
+    TVector3D gyro_reading(double /*t*/) const { return TVector3D{0, 0, yaw_rate} + bias_gyro; }
+
+    /// The true gravity vector expressed in {M}: what the estimator must find.
+    TVector3D gravity_in_map() const
+    {
+        const Eigen::Vector3d g = R_map_from_world().asEigen() * Eigen::Vector3d(0, 0, -GRAVITY);
+        return {g.x(), g.y(), g.z()};
+    }
+
+    static Eigen::Vector3d toE(const TVector3D& v) { return {v.x, v.y, v.z}; }
+};
+
+/** Noise densities of a typical MEMS IMU (sigma units: rad/s/sqrt(Hz) and
+ *  m/s^2/sqrt(Hz)). NOTE: ImuIntegrationParams defaults to IDENTITY
+ *  covariances, i.e. sigma=1 for both, which is ~1000x worse than any real
+ *  sensor; using that here would make every "earned" sigma so large that the
+ *  estimator would rightly never report convergence.
+ */
+ImuIntegrationParams realisticImuParams()
+{
+    ImuIntegrationParams p;
+    p.cov_gyro.setDiagonal(mrpt::square(3e-3));
+    p.cov_acc.setDiagonal(mrpt::square(3e-2));
+    return p;
+}
+
+/// Builds one interval of the given duration, preintegrating at `rate` Hz.
+MapGravityEstimator::Interval makeInterval(
+    const SyntheticWorld& w, double t0, double t1, double rate,
+    const ImuIntegrationParams& imuParams, std::mt19937* rng = nullptr, double accelNoise = 0,
+    double gyroNoise = 0)
+{
+    ImuPreintegrator pim(imuParams);
+    pim.reset_integration();
+
+    const double dt = 1.0 / rate;
+    const int    n  = static_cast<int>(std::llround((t1 - t0) / dt));
+
+    std::normal_distribution<double> nd(0.0, 1.0);
+
+    for (int k = 0; k < n; k++)
+    {
+        const double t = t0 + k * dt;
+        TVector3D    a = w.accel_reading(t);
+        TVector3D    g = w.gyro_reading(t);
+        if (rng != nullptr)
+        {
+            a = a + TVector3D{nd(*rng) * accelNoise, nd(*rng) * accelNoise, nd(*rng) * accelNoise};
+            g = g + TVector3D{nd(*rng) * gyroNoise, nd(*rng) * gyroNoise, nd(*rng) * gyroNoise};
+        }
+        pim.integrate_measurement(a, g, dt);
+    }
+
+    MapGravityEstimator::Interval itv;
+    itv.t_from = t0;
+    // The interval is delimited by the KEYFRAME stamps, as in the real
+    // wiring; whether the IMU samples actually cover it is what the coverage
+    // guard is there to check.
+    itv.t_to   = t1;
+    itv.delta  = pim.current_state();
+    itv.R_from = w.R_map_body(itv.t_from);
+    itv.R_to   = w.R_map_body(itv.t_to);
+    itv.v_from = w.v_map(itv.t_from);
+    itv.v_to   = w.v_map(itv.t_to);
+    return itv;
+}
+
+/// Angle between two vectors [deg].
+double angleBetweenDeg(const TVector3D& a, const TVector3D& b)
+{
+    const double na = a.norm();
+    const double nb = b.norm();
+    ASSERT_GT_(na, 0);
+    ASSERT_GT_(nb, 0);
+    const double c = std::clamp((a.x * b.x + a.y * b.y + a.z * b.z) / (na * nb), -1.0, 1.0);
+    return mrpt::RAD2DEG(std::acos(c));
+}
+
+/// Runs a full sequence of intervals through the estimator.
+MapGravityEstimator::Result runSequence(
+    MapGravityEstimator& est, const SyntheticWorld& w, const ImuIntegrationParams& imuParams,
+    int numIntervals, double intervalDuration = 0.5, double rate = 200.0,
+    std::mt19937* rng = nullptr, double accelNoise = 0, double gyroNoise = 0)
+{
+    for (int k = 0; k < numIntervals; k++)
+    {
+        const double t0 = k * intervalDuration;
+        const auto   itv =
+            makeInterval(w, t0, t0 + intervalDuration, rate, imuParams, rng, accelNoise, gyroNoise);
+
+        const bool ok = est.add_interval(itv);
+        ASSERTMSG_(ok, std::string("interval rejected: ") + est.last_rejection_reason());
+    }
+    ASSERT_(est.solve());
+    ASSERT_(est.latest_result().has_value());
+    return *est.latest_result();
+}
+
+// -----------------------------------------------------------------------
+// THE key test: a tilted map, a trajectory that never stops, raw IMU only.
+// -----------------------------------------------------------------------
+void test_recovers_map_tilt_while_always_moving()
+{
+    SyntheticWorld w;
+    w.map_tilt = {mrpt::DEG2RAD(2.5), mrpt::DEG2RAD(-1.8), 0.0};  // ~3.1 deg of tilt
+
+    MapGravityEstimator est;
+    const auto          res = runSequence(est, w, realisticImuParams(), 20);
+
+    const double dirErrDeg = angleBetweenDeg(res.gravity_in_map, w.gravity_in_map());
+
+    ASSERTMSG_(
+        dirErrDeg < 0.05,
+        mrpt::format(
+            "gravity direction error too large: %.4f deg (estimated %s, true %s)", dirErrDeg,
+            res.gravity_in_map.asString().c_str(), w.gravity_in_map().asString().c_str()));
+
+    ASSERT_NEAR_(res.gravity_in_map.norm(), GRAVITY, 0.02);
+    ASSERT_(res.converged);
+
+    // The correction must actually level the map: applying it to the measured
+    // gravity has to yield (0,0,-g).
+    const Eigen::Vector3d leveled =
+        res.correction.asEigen() *
+        Eigen::Vector3d(res.gravity_in_map.x, res.gravity_in_map.y, res.gravity_in_map.z);
+    ASSERT_NEAR_(leveled.x(), 0.0, 1e-6);
+    ASSERT_NEAR_(leveled.y(), 0.0, 1e-6);
+    ASSERT_LT_(leveled.z(), 0.0);
+
+    std::cout << "test_recovers_map_tilt_while_always_moving passed (dir err " << dirErrDeg
+              << " deg, tilt " << mrpt::RAD2DEG(res.tilt) << " deg, " << res.iterations
+              << " iters)." << std::endl;
+}
+
+// A level map must be reported as level: no phantom tilt.
+void test_level_map_yields_no_correction()
+{
+    SyntheticWorld w;  // map_tilt = 0
+
+    MapGravityEstimator est;
+    const auto          res = runSequence(est, w, realisticImuParams(), 20);
+
+    ASSERTMSG_(
+        mrpt::RAD2DEG(res.tilt) < 0.05,
+        mrpt::format("phantom tilt on a level map: %.4f deg", mrpt::RAD2DEG(res.tilt)));
+
+    std::cout << "test_level_map_yields_no_correction passed (tilt " << mrpt::RAD2DEG(res.tilt)
+              << " deg)." << std::endl;
+}
+
+// -----------------------------------------------------------------------
+// Bias observability.
+// -----------------------------------------------------------------------
+void test_gyro_bias_observability()
+{
+    SyntheticWorld w;
+    w.map_tilt  = {mrpt::DEG2RAD(1.0), mrpt::DEG2RAD(1.5), 0};
+    w.bias_gyro = {0.004, -0.003, 0.002};  // rad/s
+
+    // (a) With a DELIBERATELY LOOSE prior, the bias must be recovered almost
+    //     exactly. This is what proves the residual and its Jacobian are
+    //     correctly scaled, as opposed to merely "close".
+    {
+        MapGravityEstimator est;
+        est.parameters.bias_gyro_prior_sigma = 1.0;  // effectively no prior
+
+        const auto   res = runSequence(est, w, realisticImuParams(), 20);
+        const double err = (res.bias_gyro - w.bias_gyro).norm();
+
+        ASSERTMSG_(
+            err < 5e-5, mrpt::format(
+                            "gyro bias not recovered with a loose prior: estimated %s vs true %s "
+                            "(err %g rad/s)",
+                            res.bias_gyro.asString().c_str(), w.bias_gyro.asString().c_str(), err));
+
+        std::cout << "  loose prior: bias err " << err << " rad/s" << std::endl;
+    }
+
+    // (b) With the DEFAULT (tight, zero-anchored) prior, the estimate is
+    //     deliberately shrunk toward zero: that is the prior working as
+    //     designed, and is what keeps the bias bounded when the data is weak.
+    //     It must still recover most of the true bias, and must not overshoot.
+    {
+        MapGravityEstimator est;
+        const auto          res = runSequence(est, w, realisticImuParams(), 20);
+
+        const double trueNorm = w.bias_gyro.norm();
+        const double recovered =
+            (res.bias_gyro.x * w.bias_gyro.x + res.bias_gyro.y * w.bias_gyro.y +
+             res.bias_gyro.z * w.bias_gyro.z) /
+            (trueNorm * trueNorm);
+
+        ASSERTMSG_(
+            recovered > 0.8 && recovered <= 1.0,
+            mrpt::format(
+                "gyro bias shrinkage out of the expected range: recovered fraction %.3f "
+                "(estimated %s vs true %s)",
+                recovered, res.bias_gyro.asString().c_str(), w.bias_gyro.asString().c_str()));
+
+        // and the tilt must still come out right despite the bias:
+        const double dirErrDeg = angleBetweenDeg(res.gravity_in_map, w.gravity_in_map());
+        ASSERT_LT_(dirErrDeg, 0.1);
+
+        std::cout << "  default prior: recovered fraction " << recovered << ", dir err "
+                  << dirErrDeg << " deg" << std::endl;
+    }
+
+    std::cout << "test_gyro_bias_observability passed." << std::endl;
+}
+
+void test_accel_bias_observability_with_rotation_excitation()
+{
+    SyntheticWorld w;
+    w.map_tilt = {mrpt::DEG2RAD(2.0), mrpt::DEG2RAD(-1.0), 0};
+    w.bias_acc = {0.05, -0.04, 0.03};  // m/s^2
+    w.yaw_rate = 0.6;  // plenty of rotation excitation
+
+    // (a) Loose prior: rotation excitation makes the accelerometer bias
+    //     separable from gravity (the bias rotates with the body while gravity
+    //     stays fixed in the map frame), so it must be recovered accurately.
+    {
+        MapGravityEstimator est;
+        est.parameters.bias_acc_prior_sigma = 10.0;  // effectively no prior
+
+        const auto   res = runSequence(est, w, realisticImuParams(), 30);
+        const double err = (res.bias_acc - w.bias_acc).norm();
+
+        // The floor here is the first-order discretization error of the
+        // Euler-forward preintegration at 200 Hz, which biases dV slightly and
+        // is partly absorbed by the accel bias. It is ~1e-3 m/s^2, far below
+        // any real accelerometer's bias instability.
+        ASSERTMSG_(
+            err < 5e-3, mrpt::format(
+                            "accel bias not recovered with a loose prior: estimated %s vs true %s "
+                            "(err %g m/s^2)",
+                            res.bias_acc.asString().c_str(), w.bias_acc.asString().c_str(), err));
+
+        const double dirErrDeg = angleBetweenDeg(res.gravity_in_map, w.gravity_in_map());
+        ASSERT_LT_(dirErrDeg, 0.05);
+
+        std::cout << "  loose prior: bias err " << err << " m/s^2, dir err " << dirErrDeg << " deg"
+                  << std::endl;
+    }
+
+    // (b) Default prior: the accelerometer bias is shrunk noticeably harder
+    //     than the gyro one, because it trades directly against the gravity
+    //     direction we are trying to estimate. What matters is that it moves
+    //     the RIGHT WAY and stays bounded, and that the tilt is still right.
+    {
+        MapGravityEstimator est;
+        const auto          res = runSequence(est, w, realisticImuParams(), 30);
+
+        const double trueNorm  = w.bias_acc.norm();
+        const double recovered = (res.bias_acc.x * w.bias_acc.x + res.bias_acc.y * w.bias_acc.y +
+                                  res.bias_acc.z * w.bias_acc.z) /
+                                 (trueNorm * trueNorm);
+
+        ASSERTMSG_(
+            recovered > 0.3 && recovered <= 1.0,
+            mrpt::format(
+                "accel bias shrinkage out of the expected range: recovered fraction %.3f "
+                "(estimated %s vs true %s)",
+                recovered, res.bias_acc.asString().c_str(), w.bias_acc.asString().c_str()));
+
+        const double dirErrDeg = angleBetweenDeg(res.gravity_in_map, w.gravity_in_map());
+        ASSERT_LT_(dirErrDeg, 0.3);
+
+        std::cout << "  default prior: recovered fraction " << recovered << ", dir err "
+                  << dirErrDeg << " deg" << std::endl;
+    }
+
+    std::cout << "test_accel_bias_observability_with_rotation_excitation passed." << std::endl;
+}
+
+// Without rotation excitation the accel bias and a tilt are indistinguishable.
+// The point of this test is that the estimator degrades GRACEFULLY (the prior
+// dominates, nothing diverges), not that it magically recovers the truth.
+void test_no_rotation_excitation_degrades_gracefully()
+{
+    SyntheticWorld w;
+    w.map_tilt  = {mrpt::DEG2RAD(1.5), 0, 0};
+    w.bias_acc  = {0.05, -0.04, 0.0};
+    w.yaw_rate  = 0.0;  // no rotation at all
+    w.body_tilt = {0, 0, 0};  // and level body
+
+    MapGravityEstimator est;
+    const auto          res = runSequence(est, w, realisticImuParams(), 20);
+
+    ASSERT_(std::isfinite(res.tilt));
+    ASSERT_(std::isfinite(res.bias_acc.norm()));
+    // The prior must keep the bias bounded rather than letting it run away:
+    ASSERT_LT_(res.bias_acc.norm(), 3.0 * est.parameters.bias_acc_prior_sigma);
+    // And the magnitude constraint must keep |g| sane:
+    ASSERT_NEAR_(res.gravity_in_map.norm(), GRAVITY, 0.5);
+
+    std::cout << "test_no_rotation_excitation_degrades_gracefully passed (tilt "
+              << mrpt::RAD2DEG(res.tilt) << " deg, |b_a| " << res.bias_acc.norm() << ")."
+              << std::endl;
+}
+
+// -----------------------------------------------------------------------
+// Robustness.
+// -----------------------------------------------------------------------
+void test_huber_rejects_corrupted_velocity()
+{
+    SyntheticWorld w;
+    w.map_tilt = {mrpt::DEG2RAD(2.0), mrpt::DEG2RAD(-1.5), 0};
+
+    // Reference run, all intervals clean:
+    MapGravityEstimator estClean;
+    const auto          clean = runSequence(estClean, w, realisticImuParams(), 20);
+
+    // Same, but one interval has a grossly wrong odometry velocity:
+    MapGravityEstimator est;
+    for (int k = 0; k < 20; k++)
+    {
+        const double t0  = k * 0.5;
+        auto         itv = makeInterval(w, t0, t0 + 0.5, 200.0, realisticImuParams());
+        if (k == 10)
+        {
+            itv.v_to = itv.v_to + TVector3D{5.0, -4.0, 3.0};  // a badly wrong LO velocity
+        }
+        ASSERT_(est.add_interval(itv));
+    }
+    ASSERT_(est.solve());
+    const auto res = *est.latest_result();
+
+    const double dirErrDeg = angleBetweenDeg(res.gravity_in_map, w.gravity_in_map());
+    ASSERTMSG_(
+        dirErrDeg < 0.5, mrpt::format(
+                             "outlier dragged the estimate: %.4f deg (clean run: %.4f deg)",
+                             dirErrDeg, angleBetweenDeg(clean.gravity_in_map, w.gravity_in_map())));
+
+    std::cout << "test_huber_rejects_corrupted_velocity passed (dir err " << dirErrDeg << " deg)."
+              << std::endl;
+}
+
+void test_survives_realistic_noise()
+{
+    SyntheticWorld w;
+    w.map_tilt  = {mrpt::DEG2RAD(2.0), mrpt::DEG2RAD(-2.0), 0};
+    w.bias_gyro = {0.002, 0.001, -0.001};
+
+    const double rate   = 200.0;
+    const double sigmaG = 3e-3;  // rad/s/sqrt(Hz)
+    const double sigmaA = 3e-2;  // m/s^2/sqrt(Hz)
+
+    ImuIntegrationParams imuParams;
+    imuParams.cov_gyro.setDiagonal(sigmaG * sigmaG);
+    imuParams.cov_acc.setDiagonal(sigmaA * sigmaA);
+
+    std::mt19937 rng(1234);
+
+    MapGravityEstimator est;
+    const auto          res = runSequence(
+                 est, w, imuParams, 30, 0.5, rate, &rng, sigmaA * std::sqrt(rate), sigmaG * std::sqrt(rate));
+
+    const double dirErrDeg = angleBetweenDeg(res.gravity_in_map, w.gravity_in_map());
+    ASSERTMSG_(
+        dirErrDeg < 1.0,
+        mrpt::format("noisy-run gravity direction error too large: %.4f deg", dirErrDeg));
+    ASSERT_(res.converged);
+
+    std::cout << "test_survives_realistic_noise passed (dir err " << dirErrDeg
+              << " deg, reported sigma pitch/roll " << mrpt::RAD2DEG(res.pitch_sigma) << "/"
+              << mrpt::RAD2DEG(res.roll_sigma) << " deg)." << std::endl;
+}
+
+// -----------------------------------------------------------------------
+// Guards and bookkeeping.
+// -----------------------------------------------------------------------
+void test_coverage_guard_rejects_truncated_window()
+{
+    SyntheticWorld w;
+
+    MapGravityEstimator est;
+
+    // An interval whose samples only cover the first half of it: exactly the
+    // failure that silently corrupts a preintegrated constraint.
+    auto itv = makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams());
+    itv.t_to = itv.t_from + 1.0;  // claim twice the duration actually integrated
+
+    ASSERT_(!est.add_interval(itv));
+    ASSERT_(!est.last_rejection_reason().empty());
+    ASSERT_EQUAL_(est.window_length(), 0U);
+
+    std::cout << "test_coverage_guard_rejects_truncated_window passed (\""
+              << est.last_rejection_reason() << "\")." << std::endl;
+}
+
+void test_input_guards()
+{
+    SyntheticWorld w;
+
+    MapGravityEstimator est;
+
+    // Empty delta:
+    {
+        MapGravityEstimator::Interval itv;
+        itv.t_from = 0;
+        itv.t_to   = 0.5;
+        ASSERT_(!est.add_interval(itv));
+    }
+    // Non-positive duration:
+    {
+        auto itv = makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams());
+        itv.t_to = itv.t_from;
+        ASSERT_(!est.add_interval(itv));
+    }
+    // Non-finite velocity:
+    {
+        auto itv   = makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams());
+        itv.v_to.x = std::numeric_limits<double>::quiet_NaN();
+        ASSERT_(!est.add_interval(itv));
+    }
+    // Out-of-order:
+    {
+        ASSERT_(est.add_interval(makeInterval(w, 1.0, 1.5, 200.0, realisticImuParams())));
+        ASSERT_(!est.add_interval(makeInterval(w, 0.0, 0.5, 200.0, realisticImuParams())));
+    }
+
+    // Solving with a single interval must not crash (it is simply weak):
+    ASSERT_(est.solve());
+    ASSERT_(est.latest_result().has_value());
+    ASSERT_(!est.latest_result()->converged);  // too few intervals
+
+    std::cout << "test_input_guards passed." << std::endl;
+}
+
+void test_window_slides_and_resets()
+{
+    SyntheticWorld w;
+
+    MapGravityEstimator est;
+    est.parameters.window_size = 5;
+
+    for (int k = 0; k < 12; k++)
+    {
+        const double t0 = k * 0.5;
+        ASSERT_(est.add_interval(makeInterval(w, t0, t0 + 0.5, 200.0, realisticImuParams())));
+    }
+    ASSERT_EQUAL_(est.window_length(), 5U);
+
+    est.reset();
+    ASSERT_EQUAL_(est.window_length(), 0U);
+    ASSERT_(!est.latest_result().has_value());
+
+    std::cout << "test_window_slides_and_resets passed." << std::endl;
+}
+
+void test_correction_from_gravity_degenerate_inputs()
+{
+    // Zero vector: identity, no crash.
+    ASSERT_LT_(so3_log(MapGravityEstimator::correction_from_gravity({0, 0, 0})).norm(), 1e-12);
+
+    // Already level: identity.
+    ASSERT_LT_(
+        so3_log(MapGravityEstimator::correction_from_gravity({0, 0, -GRAVITY})).norm(), 1e-12);
+
+    // Upside down: a valid 180 deg rotation, and it must still level.
+    {
+        const auto            C = MapGravityEstimator::correction_from_gravity({0, 0, GRAVITY});
+        const Eigen::Vector3d leveled = C.asEigen() * Eigen::Vector3d(0, 0, GRAVITY);
+        ASSERT_NEAR_(leveled.z(), -GRAVITY, 1e-9);
+    }
+
+    // The correction must carry NO yaw, so a pure-roll gravity tilt yields a
+    // pure-roll correction.
+    {
+        const double    a = mrpt::DEG2RAD(5.0);
+        const TVector3D g{0, GRAVITY * std::sin(a), -GRAVITY * std::cos(a)};
+        const auto      C = MapGravityEstimator::correction_from_gravity(g);
+
+        mrpt::poses::CPose3D p;
+        p.setRotationMatrix(C);
+        ASSERT_NEAR_(p.yaw(), 0.0, 1e-9);
+        ASSERT_NEAR_(std::abs(p.roll()), a, 1e-9);
+    }
+
+    std::cout << "test_correction_from_gravity_degenerate_inputs passed." << std::endl;
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_recovers_map_tilt_while_always_moving();
+        test_level_map_yields_no_correction();
+        test_gyro_bias_observability();
+        test_accel_bias_observability_with_rotation_excitation();
+        test_no_rotation_excitation_degrades_gracefully();
+        test_huber_rejects_corrupted_velocity();
+        test_survives_realistic_noise();
+        test_coverage_guard_rejects_truncated_window();
+        test_input_guards();
+        test_window_slides_and_resets();
+        test_correction_from_gravity_degenerate_inputs();
+        std::cout << "All MapGravityEstimator tests passed." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/tests/test-so3-jacobians.cpp
+++ b/tests/test-so3-jacobians.cpp
@@ -1,0 +1,174 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+*/
+
+/**
+ * @file   test-so3-jacobians.cpp
+ * @brief  Unit tests for the SO(3) right Jacobian helpers.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 22, 2026
+ *
+ * The right Jacobian is validated against its DEFINING identity,
+ *   Exp(phi + delta) ~= Exp(phi) * Exp( Jr(phi) * delta ),
+ * evaluated numerically, rather than against a second closed form: a typo
+ * duplicated in both places would otherwise go unnoticed.
+ */
+
+#include <mola_imu_preintegration/so3_jacobians.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/math/geometry.h>
+
+#include <Eigen/Dense>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using namespace mola::imu;
+using mrpt::math::TVector3D;
+
+namespace
+{
+/// Numerical Jacobian of  delta -> Log( Exp(phi)^T Exp(phi + delta) )  at delta=0,
+/// which by definition equals Jr(phi).
+Eigen::Matrix3d numericalRightJacobian(const TVector3D& phi, double eps = 1e-6)
+{
+    const auto            R  = so3_exp(phi);
+    const Eigen::Matrix3d Rt = R.asEigen().transpose();
+
+    Eigen::Matrix3d J = Eigen::Matrix3d::Zero();
+    for (int i = 0; i < 3; i++)
+    {
+        TVector3D dp{0, 0, 0};
+        dp[i] = eps;
+
+        SO3 Dp;
+        SO3 Dm;
+        Dp.asEigen() = Rt * so3_exp(phi + dp).asEigen();
+        Dm.asEigen() = Rt * so3_exp(phi - dp).asEigen();
+
+        const TVector3D lp = so3_log(Dp);
+        const TVector3D lm = so3_log(Dm);
+
+        for (int r = 0; r < 3; r++)
+        {
+            J(r, i) = (lp[r] - lm[r]) / (2 * eps);
+        }
+    }
+    return J;
+}
+
+const std::vector<TVector3D> testVectors()
+{
+    return {
+        {0, 0, 0},    {1e-9, 0, 0},     {1e-5, -2e-5, 3e-6}, {0.1, 0, 0},     {0, 0.3, 0},
+        {0, 0, -0.7}, {0.3, -0.4, 0.5}, {1.5, 0.2, -1.1},    {2.9, 0.1, 0.1},
+    };
+}
+
+void test_skew_symmetric_is_cross_product()
+{
+    const TVector3D a{0.3, -1.2, 0.7};
+    const TVector3D b{-0.5, 0.9, 2.1};
+
+    const Eigen::Vector3d viaSkew = skew_symmetric(a).asEigen() * Eigen::Vector3d(b.x, b.y, b.z);
+
+    TVector3D viaCross;
+    mrpt::math::crossProduct3D(a, b, viaCross);
+
+    ASSERT_NEAR_(viaSkew.x(), viaCross.x, 1e-12);
+    ASSERT_NEAR_(viaSkew.y(), viaCross.y, 1e-12);
+    ASSERT_NEAR_(viaSkew.z(), viaCross.z, 1e-12);
+
+    std::cout << "test_skew_symmetric_is_cross_product passed." << std::endl;
+}
+
+void test_right_jacobian_matches_definition()
+{
+    for (const auto& phi : testVectors())
+    {
+        const Eigen::Matrix3d Jnum = numericalRightJacobian(phi);
+        const Eigen::Matrix3d Jana = right_jacobian_so3(phi).asEigen();
+
+        const double err = (Jnum - Jana).cwiseAbs().maxCoeff();
+        ASSERTMSG_(
+            err < 1e-6,
+            mrpt::format("Jr mismatch for phi=%s : max abs error=%g", phi.asString().c_str(), err));
+    }
+    std::cout << "test_right_jacobian_matches_definition passed." << std::endl;
+}
+
+void test_inverse_right_jacobian_is_inverse()
+{
+    for (const auto& phi : testVectors())
+    {
+        const Eigen::Matrix3d J    = right_jacobian_so3(phi).asEigen();
+        const Eigen::Matrix3d Jinv = inverse_right_jacobian_so3(phi).asEigen();
+
+        const double err = (J * Jinv - Eigen::Matrix3d::Identity()).cwiseAbs().maxCoeff();
+        ASSERTMSG_(
+            err < 1e-9,
+            mrpt::format(
+                "Jr*Jr^-1 != I for phi=%s : max abs error=%g", phi.asString().c_str(), err));
+    }
+    std::cout << "test_inverse_right_jacobian_is_inverse passed." << std::endl;
+}
+
+void test_small_angle_branch_is_continuous()
+{
+    // Straddle the Taylor/closed-form threshold (1e-4) and check the two
+    // branches agree, i.e. no discontinuity was introduced.
+    const TVector3D dir{0.6, -0.48, 0.64};
+
+    for (const double t : {0.99e-4, 1.01e-4})
+    {
+        const TVector3D phi = dir * t;
+
+        const Eigen::Matrix3d Jnum = numericalRightJacobian(phi, 1e-7);
+        const Eigen::Matrix3d Jana = right_jacobian_so3(phi).asEigen();
+
+        const double err = (Jnum - Jana).cwiseAbs().maxCoeff();
+        ASSERTMSG_(err < 1e-7, mrpt::format("Jr branch discontinuity at t=%g : error=%g", t, err));
+    }
+    std::cout << "test_small_angle_branch_is_continuous passed." << std::endl;
+}
+
+void test_exp_log_round_trip()
+{
+    for (const auto& phi : testVectors())
+    {
+        const TVector3D back = so3_log(so3_exp(phi));
+        ASSERT_NEAR_(back.x, phi.x, 1e-10);
+        ASSERT_NEAR_(back.y, phi.y, 1e-10);
+        ASSERT_NEAR_(back.z, phi.z, 1e-10);
+    }
+    std::cout << "test_exp_log_round_trip passed." << std::endl;
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_skew_symmetric_is_cross_product();
+        test_right_jacobian_matches_definition();
+        test_inverse_right_jacobian_is_inverse();
+        test_small_angle_branch_is_continuous();
+        test_exp_log_round_trip();
+        std::cout << "All SO(3) Jacobian tests passed." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Motivation

The package integrated **rotation only**: `ImuIntegrator` computes `dR = Exp((w - b_g) dt)` and nothing else, with no covariance propagation and no bias Jacobian (`D_incrR_integratedOmega` threw). This adds the missing pieces, plus an estimator built on top of them.

No GTSAM dependency is introduced: MRPT Lie algebra only.

## What is added

**`so3_jacobians.{h,cpp}`** — the SO(3) right Jacobian `Jr` and its inverse, closed form with Taylor branches below 1e-4 rad where the closed form suffers cancellation.

> Note these are **not** what `mrpt::poses::Lie::SO<3>::jacob_dexpe_de()` returns (the 9x3 Jacobian of the flattened rotation *matrix* w.r.t. the tangent vector) — a different object. Documented in the header so the confusion is not repeated.

**`ImuPreintegrator.{h,cpp}`** — real Forster preintegration: `dR`/`dV`/`dP` with the 9x9 covariance (`[theta,v,p]` order) and the five first-order bias Jacobians, so a bias update no longer requires re-integrating the raw samples. `ImuIntegrator` is left untouched as the cheap rotation-only path.

Discretization is the standard Euler-forward form (a reading is held over the *following* `dt`, rotation taken at the step start), chosen over a midpoint rule because it keeps state propagation, bias Jacobians and covariance exactly consistent with one another. The resulting first-order `dV`/`dP` error is far below sensor noise at any realistic IMU rate.

**`MapGravityEstimator.{h,cpp}`** — estimates the gravity vector **in the odometry/map frame**, plus both IMU biases, over a sliding window. Rearranging the delta definition:

```
g = ( v_j - v_i - R_i * dV_ij ) / dt_ij
```

every interval becomes a direct measurement of gravity in which **body acceleration cancels out**. Unlike averaging raw accelerometer samples — valid only while quasi-static — this stays valid while the vehicle moves arbitrarily, which is what makes it usable for keeping an odometry solution gravity-aligned.

Unknowns are **nine scalars regardless of window length**, so there are no attitude variables and no gauge freedom to pin. Dense 9x9 Gauss-Newton with a Huber loss on the gravity residual; converges in ~4 iterations.

## Load-bearing details (please do not simplify these away)

- The **zero-anchored bias priors** and the **gravity-magnitude soft constraint** are what keep the problem conditioned. Accelerometer bias is only separable from a tilt given *rotation excitation*; on a straight, level, constant-attitude run the two are indistinguishable and the prior is all that bounds the answer. There is a test asserting graceful degradation in exactly that case.
- The **interval-coverage guard** (`min_interval_coverage`, default 0.95) rejects an interval whose IMU samples do not span it. A partial delta attributed to a whole interval corrupts the constraint *silently*.
- Rejecting an interval is always safe here — the unknowns are global, so nothing is left unconstrained — unlike a full-state formulation, which needs fallback priors.

## Testing

16/16 pass. Tests validate against **ground truth**, not against a second implementation of the same equations (a duplicated typo would defeat that):

| Check | Result |
|---|---|
| `Jr` vs. its defining identity, evaluated numerically | < 1e-6 |
| Deltas vs. an analytic Lissajous trajectory | rotation 1.9e-12 deg |
| Convergence **order** vs. sample rate (50/200/800 Hz) | ~4x per step, confirms first order |
| Bias Jacobians vs. numerical diff of full re-integration | pass |
| First-order bias update vs. re-integration at perturbed bias | 0.311 deg -> 1.3e-4 deg |
| Covariance vs. 400-trial Monte Carlo | all 9 diagonals within 25% |
| **Map tilt, never stopping, raw accel+gyro** | 3.08 deg tilt recovered to **0.001 deg** |
| Gyro bias (loose prior) | 2.7e-7 rad/s |
| Accel bias (loose prior + rotation excitation) | 1.6e-3 m/s^2 |
| Realistic MEMS noise | 0.087 deg error, reports 1.04 deg sigma |

Guard cases covered: coverage guard, non-finite/out-of-order/degenerate inputs, window sliding, degenerate gravity vectors.

## A gotcha worth knowing

`ImuIntegrationParams` defaults `cov_gyro`/`cov_acc` to **identity**, i.e. sigma=1 — roughly 1000x worse than any real MEMS IMU. With those defaults every "earned" sigma comes out enormous and the estimator correctly never reports convergence. Callers must set real noise densities. Flagged in `agents.md`; happy to change the defaults in a follow-up if you prefer.

## Notes

- Purely additive: no existing API changed, all pre-existing tests still pass.
- Feature macros added for downstream guarding: `MOLA_IMU_PREINTEGRATION_HAS_FULL_PREINTEGRATION`, `MOLA_IMU_PREINTEGRATION_HAS_MAP_GRAVITY_ESTIMATOR`.
- The consumer side in `mola_lidar_odometry` (wiring this into the ICP prior's pitch/roll) is a separate, not-yet-submitted change.
- Closes several open items from the package's math review: real preintegration, covariance propagation, bias Jacobians.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full IMU preintegration with rotation, velocity, position, covariance, and bias correction support.
  * Added SO(3) rotation and Jacobian utilities.
  * Added sliding-window map-frame gravity and IMU bias estimation, including tilt correction and uncertainty reporting.
* **Documentation**
  * Added guidance on configuring and using preintegration and gravity estimation.
* **Tests**
  * Added comprehensive coverage for rotation math, preintegration accuracy, covariance, bias correction, and gravity estimation robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->