### PR TITLE
Fix O(size) pruning scan in LocalVelocityBuffer

### DIFF
--- a/src/LocalVelocityBuffer.cpp
+++ b/src/LocalVelocityBuffer.cpp
@@ -90,6 +90,12 @@ void LocalVelocityBuffer::delete_too_old_entries()
 
     auto deleteOldEntries = [&](auto& map)
     {
+        // Entries are stored in ascending timestamp order, so all the too-old
+        // ones sit at the front. Erase from the front and STOP at the first
+        // entry still within the window: everything after it is newer and must
+        // be kept. Stopping (rather than scanning to the end) keeps this
+        // amortized O(deleted) instead of O(size) per call, which matters a
+        // lot for a long-retention buffer fed at hundreds of Hz.
         for (auto it = map.begin(); it != map.end();)
         {
             if (latest - it->first > max_time_window)
@@ -98,7 +104,7 @@ void LocalVelocityBuffer::delete_too_old_entries()
             }
             else
             {
-                ++it;
+                break;
             }
         }
     };

--- a/tests/test-velocity-buffer.cpp
+++ b/tests/test-velocity-buffer.cpp
@@ -327,21 +327,36 @@ void unit_test_pruning_keeps_full_window_under_streaming()
     LocalVelocityBuffer buf;
     buf.parameters.max_time_window = 1.0;  // seconds
 
-    const double dt = 0.0025;  // 400 Hz
+    const double     dt     = 0.0025;  // 400 Hz
+    const double     t0     = 100.0;
+    const double     window = buf.parameters.max_time_window;
+    constexpr double eps    = 1e-9;
+
     for (int i = 0; i < 2000; i++)
     {
-        const double t = 100.0 + i * dt;
+        const double t = t0 + i * dt;
         buf.add_linear_acceleration(t, {0.0, 0.0, 9.81});
 
-        const double latest   = t;
-        std::size_t  expected = 0;
-        for (const auto& [ts, val] : buf.get_linear_accelerations())
+        // Expected retained set, derived INDEPENDENTLY of the buffer from the
+        // known input stream: stamp k = t0 + k*dt survives iff
+        // t_i - t_k = (i-k)*dt <= window. Boundary entries (age == window) are
+        // kept, matching the eviction predicate (which evicts on strictly >).
+        int firstKept = 0;
+        while ((i - firstKept) * dt > window + eps)
         {
-            ASSERT_(latest - ts <= buf.parameters.max_time_window + 1e-12);
-            ++expected;
+            ++firstKept;
         }
-        // The count must equal the number of stamps within the window.
-        ASSERT_EQUAL_(buf.get_linear_accelerations().size(), expected);
+        const auto& accs = buf.get_linear_accelerations();
+
+        // Count vs. the independently-derived expectation: catches OVER-pruning
+        // (deleting valid entries would drop the count below this) as well as
+        // under-pruning (unbounded growth would push it above).
+        ASSERT_EQUAL_(accs.size(), static_cast<std::size_t>(i - firstKept + 1));
+
+        // Endpoints must be exactly right: oldest retained is t0+firstKept*dt,
+        // newest is the just-inserted t.
+        ASSERT_NEAR_(accs.begin()->first, t0 + firstKept * dt, 1e-9);
+        ASSERT_NEAR_(accs.rbegin()->first, t, 1e-9);
     }
 
     // After streaming past 1 s of data, the map must be bounded to ~window/dt

--- a/tests/test-velocity-buffer.cpp
+++ b/tests/test-velocity-buffer.cpp
@@ -316,6 +316,43 @@ void unit_test_pruning_uses_latest_timestamp()
               << std::endl;
 }
 
+void unit_test_pruning_keeps_full_window_under_streaming()
+{
+    // Stream a long, steady sequence and check that at every step the buffer
+    // retains exactly the entries within the window and no more: it must
+    // neither over-prune (dropping in-window samples) nor under-prune (letting
+    // the map grow without bound). This is also the correctness guard for the
+    // early-stop in the prune loop, which relies on the entries being stored
+    // in ascending timestamp order.
+    LocalVelocityBuffer buf;
+    buf.parameters.max_time_window = 1.0;  // seconds
+
+    const double dt = 0.0025;  // 400 Hz
+    for (int i = 0; i < 2000; i++)
+    {
+        const double t = 100.0 + i * dt;
+        buf.add_linear_acceleration(t, {0.0, 0.0, 9.81});
+
+        const double latest   = t;
+        std::size_t  expected = 0;
+        for (const auto& [ts, val] : buf.get_linear_accelerations())
+        {
+            ASSERT_(latest - ts <= buf.parameters.max_time_window + 1e-12);
+            ++expected;
+        }
+        // The count must equal the number of stamps within the window.
+        ASSERT_EQUAL_(buf.get_linear_accelerations().size(), expected);
+    }
+
+    // After streaming past 1 s of data, the map must be bounded to ~window/dt
+    // entries, not the full 2000 inserted.
+    ASSERT_LT_(buf.get_linear_accelerations().size(), 500u);
+
+    std::cout << "OK LocalVelocityBuffer unit_test_pruning_keeps_full_window_under_streaming "
+                 "passed!"
+              << std::endl;
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -328,6 +365,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         unit_test_yaml_epoch_precision();
         unit_test_window_since();
         unit_test_pruning_uses_latest_timestamp();
+        unit_test_pruning_keeps_full_window_under_streaming();
     }
     catch (std::exception& e)
     {


### PR DESCRIPTION
## Problem

`LocalVelocityBuffer::delete_too_old_entries()` walked **every** stored sample on each insert. After erasing the too-old entries at the front, it kept iterating with `++it` to the end of the map instead of stopping — even though the entries are stored in ascending timestamp order, so the first in-window entry guarantees every later one is in-window too.

Harmless for the short (sub-second) de-skew buffer this class was originally written for, but **O(size) per insert** is a real problem for a long-retention buffer fed at hundreds of Hz. This surfaced while wiring the new `MapGravityEstimator` into `mola_lidar_odometry`: a 60 s gravity buffer at ~800 Hz (2x replay) re-walked ~48000 nodes on every sample. Driven from the per-IMU-sample callback under the shared state lock, that starved the LiDAR worker — `onLidar` ran 263x instead of 2892x over the same bag, the trajectory froze after 242 keyframes, and the downstream smoother eventually threw `IndeterminantLinearSystemException`.

## Fix

Stop the prune loop at the first entry inside the retention window (valid because the maps are time-ordered), making it amortized **O(deleted)** instead of O(size).

## Test

Added `unit_test_pruning_keeps_full_window_under_streaming`: streams 2000 samples at 400 Hz through a 1 s window and asserts, at every step, that the buffer keeps exactly the in-window stamps — neither over-pruning (dropping valid samples) nor under-pruning (unbounded growth). The existing out-of-order pruning test still passes, so correctness is unchanged; only the scan cost is.

Found during real-data (Oxford Spires) validation of the IMU-preintegration gravity feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved velocity buffer cleanup so outdated entries are removed efficiently while preserving the configured retention window.
  * Prevented stored data from growing unnecessarily during continuous streaming.

* **Tests**
  * Added coverage for long-running streaming scenarios to verify timestamp retention and bounded buffer size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->