### PR TITLE
ImuInitialCalibrator: readiness as a time window, plus a dispersion gate

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -21,6 +21,11 @@ Everything is GTSAM-free: MRPT Lie algebra only.
   filters for α (finite-diff) and the centripetal ω. Output `IMU_W*` channels stay full-bandwidth.
 - `ImuInitialCalibrator` — at-rest bias + pitch/roll from averaged gravity; prefers IMU orientation
   quaternion when present. Accel bias is only observable along gravity unless orientation is used.
+  Readiness is primarily a **time window** (`window_seconds`), so it means the same averaging on any
+  IMU rate; `required_samples` is only a floor. `max_direction_dispersion` defers readiness while the
+  buffered accel directions say the window is motion rather than gravity, released by
+  `dispersion_timeout`. `bias_gyro` is a plain mean: real rotation on a moving start, do not wire it
+  into a preintegrator without a staticness gate.
 - `LocalVelocityBuffer` — time-keyed ring of v/a/ω/orientation; YAML (de)serialize; window queries.
 - `trajectory_from_buffer()` — dead-reckons an SE(3) trajectory around `t=0` from one orientation
   anchor + one velocity anchor + IMU ω/accel. Specific force → coordinate accel via

--- a/agents.md
+++ b/agents.md
@@ -21,10 +21,11 @@ Everything is GTSAM-free: MRPT Lie algebra only.
   filters for α (finite-diff) and the centripetal ω. Output `IMU_W*` channels stay full-bandwidth.
 - `ImuInitialCalibrator` — at-rest bias + pitch/roll from averaged gravity; prefers IMU orientation
   quaternion when present. Accel bias is only observable along gravity unless orientation is used.
-  Readiness is primarily a **time window** (`window_seconds`), so it means the same averaging on any
-  IMU rate; `required_samples` is only a floor. `max_direction_dispersion` defers readiness while the
-  buffered accel directions say the window is motion rather than gravity, released by
-  `dispersion_timeout`. `bias_gyro` is a plain mean: real rotation on a moving start, do not wire it
+  Readiness can be a **time window** (`window_seconds`, opt-in: the class default 0 keeps the legacy
+  sample-count rule), so it means the same averaging on any IMU rate; with a window set,
+  `required_samples` degrades to a floor. `max_direction_dispersion` (also default 0, i.e. gate off)
+  defers readiness while the buffered accel directions say the window is motion rather than gravity,
+  released by `dispersion_timeout`. The shipped LO pipelines opt into both. `bias_gyro` is a plain mean: real rotation on a moving start, do not wire it
   into a preintegrator without a staticness gate.
 - `LocalVelocityBuffer` — time-keyed ring of v/a/ω/orientation; YAML (de)serialize; window queries.
 - `trajectory_from_buffer()` — dead-reckons an SE(3) trajectory around `t=0` from one orientation

--- a/include/mola_imu_preintegration/ImuInitialCalibrator.h
+++ b/include/mola_imu_preintegration/ImuInitialCalibrator.h
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <map>
 #include <optional>
+#include <string>
 
 namespace mola::imu
 {
@@ -53,6 +54,38 @@ class ImuInitialCalibrator
          * accelerometer data. Should be normally preferable, so default is true.
          */
         bool use_imu_orientation = true;
+
+        /** Length of the averaging window, in **seconds** [s]. This is the knob that actually
+         * determines the accuracy of the estimated attitude, since the error is dominated by
+         * platform motion during the window and not by sensor noise. Being a duration, it is
+         * independent of the IMU rate: `required_samples` alone means a different averaging
+         * time on every sensor, and cannot even be satisfied by a low-rate IMU if it does not
+         * fit within `max_samples_age`.
+         *
+         * When >0, `required_samples` degrades to a minimum-sample sanity floor, the buffer is
+         * pruned to (slightly more than) this window instead of `max_samples_age`, and the
+         * calibration averages only the samples inside it.
+         *
+         * 0 (default) disables it and restores the legacy sample-count-only readiness rule.
+         */
+        double window_seconds = .0;
+
+        /** Maximum RMS angular dispersion [rad] of the buffered accelerometer directions for the
+         * window to be accepted as actually measuring gravity. A window taken while the platform
+         * is being jostled freezes a reading that is not gravity, so isReady() defers and the
+         * caller is expected to retry later with a fresher window.
+         *
+         * 0 (default) disables the gate.
+         */
+        double max_direction_dispersion = .0;
+
+        /** How long [s] the dispersion gate may defer readiness before it gives up and accepts
+         * the most recent window anyway. Measured from the first sample ever inserted, in sensor
+         * time. Without it, a platform that never becomes quiet would never initialize.
+         *
+         * 0 (default) means "no timeout", i.e. wait indefinitely for a quiet window.
+         */
+        double dispersion_timeout = .0;
     };
 
     Parameters parameters;
@@ -77,11 +110,37 @@ class ImuInitialCalibrator
         std::string asString() const;
     };
 
+    /// Detailed outcome of the readiness check, for logging and testing.
+    struct Readiness
+    {
+        Readiness() = default;
+
+        bool ready = false;  //!< Whether getCalibration() would return a value
+
+        std::size_t samples   = 0;  //!< Samples inside the averaging window
+        double      span      = 0;  //!< Time span of the averaging window [s]
+        double      elapsed   = 0;  //!< Time since the first sample ever inserted [s]
+        bool        timed_out = false;  //!< Accepted only because the gate timed out
+        std::string reason;  //!< Why it is not ready yet (empty if ready)
+
+        /// RMS angular dispersion of the accelerometer directions [rad], if computable
+        std::optional<double> dispersion;
+    };
+
     /// Inserts an IMU observation into the queue
     void add(const mrpt::obs::CObservationIMU::ConstPtr& obs);
 
     /// Returns true if there are already samples enough in the buffer to call getCalibration()
     [[nodiscard]] bool isReady() const;
+
+    /// Same as isReady(), plus the quantities the decision was made on
+    [[nodiscard]] Readiness readiness() const;
+
+    /// RMS angular spread [rad] of the buffered accelerometer directions about their mean,
+    /// over the averaging window. A quasi-static platform gives ~0; anything larger means the
+    /// accelerometer is measuring platform motion on top of gravity. Returns nothing if there
+    /// are fewer than 2 usable samples.
+    [[nodiscard]] std::optional<double> directionDispersion() const;
 
     /// If enough samples are given, it computes the initial rough IMU calibration
     [[nodiscard]] std::optional<Results> getCalibration() const;
@@ -93,9 +152,25 @@ class ImuInitialCalibrator
     /// (accel, gyro AND the absolute-orientation quaternion; placeholder identity
     /// orientations from non-attitude IMUs are dropped on insertion):
     std::map<double, const mrpt::obs::CObservationIMU> samples_;
+
+    /// Timestamp of the first sample ever inserted, to measure the gate timeout in sensor time
+    std::optional<double> first_sample_time_;
+
+    /// How far back samples are kept [s]. In time-window mode this is the window itself (plus a
+    /// small margin, so the buffer can actually span it), and `max_samples_age` is unused.
+    [[nodiscard]] double bufferHorizon() const;
+
+    using const_iterator = std::map<double, const mrpt::obs::CObservationIMU>::const_iterator;
+
+    /// First sample of the averaging window: in time-window mode, the oldest one no older than
+    /// `window_seconds`; otherwise the whole buffer.
+    [[nodiscard]] const_iterator windowBegin() const;
 };
 
 // Remove when all distros have the version with "use_imu_orientation"
 #define MOLA_IMU_PREINT_HAS_USE_IMU_ORIENT_PARAM
+
+// Remove when all distros have the version with the time window and dispersion gate
+#define MOLA_IMU_PREINT_HAS_INIT_TIME_WINDOW
 
 }  // namespace mola::imu

--- a/src/ImuInitialCalibrator.cpp
+++ b/src/ImuInitialCalibrator.cpp
@@ -32,17 +32,42 @@
 #include <mrpt/poses/SO_SE_average.h>
 
 #include <Eigen/Dense>  // required by MRPT matrix transpose()/operator* below
+#include <algorithm>
 #include <cmath>
 #include <exception>
+#include <functional>
+#include <iterator>
 #include <sstream>
 
 using namespace mola::imu;
+
+double ImuInitialCalibrator::bufferHorizon() const
+{
+    if (parameters.window_seconds <= 0)
+    {
+        return parameters.max_samples_age;
+    }
+    // Comfortably more than the window: pruning exactly at the window would keep the buffer
+    // shorter than it, so "the window is complete" could only ever be true by an exact
+    // floating-point coincidence, and at low sample rates never at all. Only the newest
+    // `window_seconds` take part in the average, see windowBegin().
+    return 2.0 * parameters.window_seconds;
+}
+
+ImuInitialCalibrator::const_iterator ImuInitialCalibrator::windowBegin() const
+{
+    if (parameters.window_seconds <= 0 || samples_.empty())
+    {
+        return samples_.begin();
+    }
+    return samples_.lower_bound(samples_.rbegin()->first - parameters.window_seconds);
+}
 
 void ImuInitialCalibrator::add(const mrpt::obs::CObservationIMU::ConstPtr& obs)
 {
     ASSERT_(obs);
     ASSERT_(parameters.required_samples > 2);
-    ASSERT_(parameters.max_samples_age > 0);
+    ASSERT_(bufferHorizon() > 0);
 
     // Rotate accel/gyro so they are body (base_link) frame-referenced:
     mrpt::obs::CObservationIMU bodyImu = imu_transformers_[obs->sensorLabel].process(*obs);
@@ -114,21 +139,136 @@ void ImuInitialCalibrator::add(const mrpt::obs::CObservationIMU::ConstPtr& obs)
     }
 
     // Add IMU reading (now fully body frame-referenced, orientation included):
-    samples_.emplace(mrpt::Clock::toDouble(obs->timestamp), std::move(bodyImu));
+    const double t = mrpt::Clock::toDouble(obs->timestamp);
+    samples_.emplace(t, std::move(bodyImu));
+
+    if (!first_sample_time_.has_value())
+    {
+        first_sample_time_ = t;
+    }
 
     // Remove old samples:
-    while (!samples_.empty() &&
-           samples_.begin()->first < samples_.rbegin()->first - parameters.max_samples_age)
+    const double horizon = bufferHorizon();
+    while (!samples_.empty() && samples_.begin()->first < samples_.rbegin()->first - horizon)
     {
         samples_.erase(samples_.begin());
     }
 }
 
-bool ImuInitialCalibrator::isReady() const
+std::optional<double> ImuInitialCalibrator::directionDispersion() const
 {
-    // samples enough?
-    return (samples_.size() >= parameters.required_samples);
+    const auto itFirst = windowBegin();
+
+    // Mean direction of the accelerometer readings:
+    mrpt::math::TVector3D mean(0, 0, 0);
+    std::size_t           count = 0;
+
+    auto forEachDirection = [&](const std::function<void(const mrpt::math::TVector3D&)>& f)
+    {
+        for (auto it = itFirst; it != samples_.end(); ++it)
+        {
+            const auto& imu = it->second;
+            const auto  acc = mrpt::math::TVector3D(
+                 imu.get(mrpt::obs::IMU_X_ACC), imu.get(mrpt::obs::IMU_Y_ACC),
+                 imu.get(mrpt::obs::IMU_Z_ACC));
+            const double n = acc.norm();
+            if (n < 1e-6)
+            {
+                continue;
+            }
+            f(acc * (1.0 / n));
+        }
+    };
+
+    forEachDirection(
+        [&](const mrpt::math::TVector3D& u)
+        {
+            mean += u;
+            ++count;
+        });
+
+    if (count < 2)
+    {
+        return {};
+    }
+
+    const double meanNorm = mean.norm();
+    if (meanNorm < 1e-6)
+    {
+        return {};
+    }
+    mean *= 1.0 / meanNorm;
+
+    // RMS angle of each direction about the mean direction:
+    double sumSqAngle = 0;
+    forEachDirection(
+        [&](const mrpt::math::TVector3D& u)
+        {
+            const double c = std::clamp(u.x * mean.x + u.y * mean.y + u.z * mean.z, -1.0, 1.0);
+            sumSqAngle += mrpt::square(std::acos(c));
+        });
+
+    return std::sqrt(sumSqAngle / static_cast<double>(count));
 }
+
+ImuInitialCalibrator::Readiness ImuInitialCalibrator::readiness() const
+{
+    Readiness r;
+
+    const auto itFirst = windowBegin();
+    r.samples          = static_cast<std::size_t>(std::distance(itFirst, samples_.end()));
+
+    if (samples_.empty())
+    {
+        r.reason = "no IMU samples yet";
+        return r;
+    }
+
+    const double newest = samples_.rbegin()->first;
+
+    // Reported span is the one that will actually be averaged; the completeness test below uses
+    // the whole buffer instead. Samples inside the window are by construction no older than
+    // `window_seconds`, so their span can only reach it by exact floating-point coincidence.
+    r.span    = newest - itFirst->first;
+    r.elapsed = newest - first_sample_time_.value_or(itFirst->first);
+
+    // Minimum-sample sanity floor. It only rejects a degenerate handful of samples: what sets
+    // the averaging time is window_seconds, since the error is dominated by platform motion
+    // during the window and not by sensor noise.
+    if (r.samples < parameters.required_samples)
+    {
+        r.reason = "not enough samples yet";
+        return r;
+    }
+
+    if (parameters.window_seconds > 0 &&
+        (newest - samples_.begin()->first) < parameters.window_seconds)
+    {
+        r.reason = "averaging window not filled yet";
+        return r;
+    }
+
+    r.dispersion = directionDispersion();
+
+    if (parameters.max_direction_dispersion > 0 && r.dispersion.has_value() &&
+        *r.dispersion > parameters.max_direction_dispersion)
+    {
+        // The window is not measuring gravity: freezing it would bake platform motion into the
+        // attitude. Defer, unless we have been deferring for too long already, in which case a
+        // motion-contaminated estimate still beats never initializing.
+        if (parameters.dispersion_timeout <= 0 || r.elapsed < parameters.dispersion_timeout)
+        {
+            r.reason = "accelerometer dispersion too high (platform not still)";
+            return r;
+        }
+        r.timed_out = true;
+    }
+
+    r.ready = true;
+    return r;
+}
+
+bool ImuInitialCalibrator::isReady() const { return readiness().ready; }
 
 namespace
 {
@@ -149,31 +289,38 @@ std::optional<ImuInitialCalibrator::Results> ImuInitialCalibrator::getCalibratio
         return {};
     }
 
-    auto forEachAcc = [this](const std::function<void(const mrpt::math::TVector3D& acc)>& f)
+    // Only the samples inside the averaging window take part in the calibration: in time-window
+    // mode the buffer may hold slightly more than that.
+    const auto itFirst = windowBegin();
+
+    auto forEachAcc = [&](const std::function<void(const mrpt::math::TVector3D& acc)>& f)
     {
-        for (const auto& [_, imu] : samples_)
+        for (auto it = itFirst; it != samples_.end(); ++it)
         {
-            const auto accel_base_link = mrpt::math::TVector3D(
-                imu.get(mrpt::obs::IMU_X_ACC), imu.get(mrpt::obs::IMU_Y_ACC),
-                imu.get(mrpt::obs::IMU_Z_ACC));
+            const auto& imu             = it->second;
+            const auto  accel_base_link = mrpt::math::TVector3D(
+                 imu.get(mrpt::obs::IMU_X_ACC), imu.get(mrpt::obs::IMU_Y_ACC),
+                 imu.get(mrpt::obs::IMU_Z_ACC));
             f(accel_base_link);
         }
     };
 
-    auto forEachGyro = [this](const std::function<void(const mrpt::math::TVector3D& omega)>& f)
+    auto forEachGyro = [&](const std::function<void(const mrpt::math::TVector3D& omega)>& f)
     {
-        for (const auto& [_, imu] : samples_)
+        for (auto it = itFirst; it != samples_.end(); ++it)
         {
-            const auto ang_vel_base_link = mrpt::math::TVector3D(
-                imu.get(mrpt::obs::IMU_WX), imu.get(mrpt::obs::IMU_WY), imu.get(mrpt::obs::IMU_WZ));
+            const auto& imu               = it->second;
+            const auto  ang_vel_base_link = mrpt::math::TVector3D(
+                 imu.get(mrpt::obs::IMU_WX), imu.get(mrpt::obs::IMU_WY), imu.get(mrpt::obs::IMU_WZ));
             f(ang_vel_base_link);
         }
     };
 
-    auto forEachOrientation = [this](const std::function<void(const mrpt::poses::CPose3D&)>& f)
+    auto forEachOrientation = [&](const std::function<void(const mrpt::poses::CPose3D&)>& f)
     {
-        for (const auto& [_, imu] : samples_)
+        for (auto it = itFirst; it != samples_.end(); ++it)
         {
+            const auto& imu = it->second;
             if (!imu.has(mrpt::obs::IMU_ORI_QUAT_W))
             {
                 continue;
@@ -221,7 +368,7 @@ std::optional<ImuInitialCalibrator::Results> ImuInitialCalibrator::getCalibratio
         }
     }
 
-    const std::size_t count = samples_.size();
+    const auto count = static_cast<std::size_t>(std::distance(itFirst, samples_.end()));
 
     // Average:
     const auto n_1 = [count]() { return count ? 1.0 / static_cast<double>(count) : .0; }();
@@ -276,6 +423,9 @@ std::optional<ImuInitialCalibrator::Results> ImuInitialCalibrator::getCalibratio
     results.bias_acc_b = average_accel_body - estimated_gravity_body;
 
     // Gyroscope bias:
+    // WARNING: this is the plain mean of the gyro, which is only a bias if the platform was
+    // actually still during the window. On a moving start it is real rotation rate, so it must
+    // not be fed to a preintegrator without a staticness gate first.
     results.bias_gyro = average_gyro;
 
     return results;

--- a/tests/test-imu-initial-calibrator.cpp
+++ b/tests/test-imu-initial-calibrator.cpp
@@ -749,6 +749,240 @@ void TestImuInitialCalibrator()
         std::cout << "Test 13: rotated mount + NaN orientation OK.\n";
     }
 
+    // 14. Time-window readiness is independent of the IMU rate
+    {
+        for (const double rate : {100.0, 200.0, 400.0})
+        {
+            ImuInitialCalibrator calibrator;
+            calibrator.parameters.window_seconds   = 1.0;
+            calibrator.parameters.required_samples = 20;
+
+            const double          dt = 1.0 / rate;
+            double                t  = 1000.0;
+            std::optional<double> readyAt;
+            std::size_t           readySamples = 0;
+
+            for (int i = 0; i < static_cast<int>(3 * rate); i++)
+            {
+                calibrator.add(create_imu_obs(t, {0, 0, 9.81}, {0, 0, 0}));
+                if (!readyAt.has_value())
+                {
+                    const auto r = calibrator.readiness();
+                    if (r.ready)
+                    {
+                        readyAt      = t - 1000.0;
+                        readySamples = r.samples;
+                    }
+                }
+                t += dt;
+            }
+
+            ASSERT_(readyAt.has_value());
+            MRPT_ASSERT_NEAR_MSG_(*readyAt, 1.0, 1.5 * dt, "ready time at " << rate << " Hz");
+            // Same duration, very different sample counts:
+            MRPT_ASSERT_NEAR_MSG_(
+                static_cast<double>(readySamples), rate + 1, 2.0, "samples at " << rate << " Hz");
+        }
+        std::cout << "Test 14: rate-independent time window OK.\n";
+    }
+
+    // 15. The legacy sample-count rule is rate-dependent, and unsatisfiable at low rates
+    {
+        // 400 samples at 100 Hz is 4 s of averaging, not the 1 s it is at 400 Hz:
+        ImuInitialCalibrator calibrator;
+        calibrator.parameters.required_samples = 400;
+        calibrator.parameters.max_samples_age  = 5.0;
+        calibrator.parameters.window_seconds   = 0;  // legacy mode
+
+        double t = 0;
+        for (int i = 0; i < 100; i++, t += 0.01)
+        {
+            calibrator.add(create_imu_obs(t, {0, 0, 9.81}, {0, 0, 0}));
+        }
+        ASSERT_(!calibrator.isReady());  // 1 s of data is not enough
+
+        for (int i = 0; i < 300; i++, t += 0.01)
+        {
+            calibrator.add(create_imu_obs(t, {0, 0, 9.81}, {0, 0, 0}));
+        }
+        ASSERT_(calibrator.isReady());  // only after 4 s
+
+        // And with a shorter max age it can never be satisfied at all:
+        ImuInitialCalibrator stalled;
+        stalled.parameters.required_samples = 400;
+        stalled.parameters.max_samples_age  = 3.0;
+        stalled.parameters.window_seconds   = 0;
+
+        t = 0;
+        for (int i = 0; i < 2000; i++, t += 0.01)
+        {
+            stalled.add(create_imu_obs(t, {0, 0, 9.81}, {0, 0, 0}));
+        }
+        ASSERT_(!stalled.isReady());  // 20 s in, and it never will be
+
+        // The time window does not have that failure mode:
+        ImuInitialCalibrator windowed;
+        windowed.parameters.window_seconds   = 1.0;
+        windowed.parameters.required_samples = 20;
+
+        t = 0;
+        for (int i = 0; i < 2000 && !windowed.isReady(); i++, t += 0.01)
+        {
+            windowed.add(create_imu_obs(t, {0, 0, 9.81}, {0, 0, 0}));
+        }
+        ASSERT_(windowed.isReady());
+        MRPT_ASSERT_NEAR_MSG_(t, 1.01, 0.02, "100 Hz ready time with a 1 s window");
+
+        std::cout << "Test 15: legacy sample-count rate dependence OK.\n";
+    }
+
+    // 16. The minimum-sample floor rejects a degenerate window
+    {
+        ImuInitialCalibrator calibrator;
+        calibrator.parameters.window_seconds   = 1.0;
+        calibrator.parameters.required_samples = 20;
+
+        // 10 Hz: the window fills in time, but holds ~11 samples only.
+        double t = 0;
+        for (int i = 0; i < 50; i++, t += 0.1)
+        {
+            calibrator.add(create_imu_obs(t, {0, 0, 9.81}, {0, 0, 0}));
+        }
+        const auto r = calibrator.readiness();
+        ASSERT_(!r.ready);
+        ASSERT_(r.samples < 20);
+        ASSERT_(r.span > 0.85);  // the window IS filled in time
+        ASSERT_(!r.reason.empty());
+        ASSERT_(!calibrator.getCalibration().has_value());
+
+        // Proof that the floor, and not the window, is what held it back: the very same stream
+        // with a lower floor is ready.
+        ImuInitialCalibrator lowFloor;
+        lowFloor.parameters.window_seconds   = 1.0;
+        lowFloor.parameters.required_samples = 5;
+
+        t = 0;
+        for (int i = 0; i < 50; i++, t += 0.1)
+        {
+            lowFloor.add(create_imu_obs(t, {0, 0, 9.81}, {0, 0, 0}));
+        }
+        ASSERT_(lowFloor.isReady());
+
+        std::cout << "Test 16: minimum-sample floor OK.\n";
+    }
+
+    // 17. Dispersion measurement, gate deferral, release and timeout
+    {
+        const double g          = 9.81;
+        const double wobbleRad  = mrpt::DEG2RAD(3.0);
+        const double maxDispRad = mrpt::DEG2RAD(1.5);
+        const double dt         = 1.0 / 400;
+
+        // Alternating +-wobble about vertical: the mean direction is vertical by symmetry, so
+        // the RMS angular dispersion is exactly the wobble.
+        auto wobbling = [&](int i)
+        {
+            const double s = (i % 2 == 0) ? 1.0 : -1.0;
+            return mrpt::math::TVector3D(s * g * std::sin(wobbleRad), 0, g * std::cos(wobbleRad));
+        };
+
+        {
+            ImuInitialCalibrator calibrator;
+            calibrator.parameters.window_seconds           = 1.0;
+            calibrator.parameters.required_samples         = 20;
+            calibrator.parameters.max_direction_dispersion = maxDispRad;
+            calibrator.parameters.dispersion_timeout       = 5.0;
+
+            double t = 0;
+            for (int i = 0; i < 400 * 4; i++, t += dt)
+            {
+                calibrator.add(create_imu_obs(t, wobbling(i), {0, 0, 0}));
+            }
+
+            const auto disp = calibrator.directionDispersion();
+            ASSERT_(disp.has_value());
+            MRPT_ASSERT_NEAR_MSG_(
+                *disp, wobbleRad, 1e-4,
+                "measured dispersion");  // odd sample counts tilt the mean slightly
+
+            const auto r = calibrator.readiness();
+            ASSERT_(!r.ready);  // deferred: the window is not measuring gravity
+            ASSERT_(!r.timed_out);
+            ASSERT_(r.span >= 1.0);
+            ASSERT_(r.samples >= 20);
+
+            // Keep it dynamic past the timeout: it must initialize anyway.
+            for (int i = 0; i < 400 * 2; i++, t += dt)
+            {
+                calibrator.add(create_imu_obs(t, wobbling(i), {0, 0, 0}));
+            }
+            const auto r2 = calibrator.readiness();
+            ASSERT_(r2.ready);
+            ASSERT_(r2.timed_out);
+            ASSERT_(r2.elapsed >= 5.0);
+            ASSERT_(calibrator.getCalibration().has_value());
+        }
+
+        {
+            // Same start, but the platform becomes still before the timeout:
+            ImuInitialCalibrator calibrator;
+            calibrator.parameters.window_seconds           = 1.0;
+            calibrator.parameters.required_samples         = 20;
+            calibrator.parameters.max_direction_dispersion = maxDispRad;
+            calibrator.parameters.dispersion_timeout       = 5.0;
+
+            double t = 0;
+            for (int i = 0; i < 400 * 2; i++, t += dt)
+            {
+                calibrator.add(create_imu_obs(t, wobbling(i), {0, 0, 0}));
+            }
+            ASSERT_(!calibrator.isReady());
+
+            for (int i = 0; i < 400 * 2 && !calibrator.isReady(); i++, t += dt)
+            {
+                calibrator.add(create_imu_obs(t, {0, 0, g}, {0, 0, 0}));
+            }
+
+            const auto r = calibrator.readiness();
+            ASSERT_(r.ready);
+            ASSERT_(!r.timed_out);  // released by the data, not by the clock
+            ASSERT_(r.elapsed < 5.0);
+        }
+
+        std::cout << "Test 17: dispersion gate defer/release/timeout OK.\n";
+    }
+
+    // 18. Only the samples inside the window take part in the average
+    {
+        const double g       = 9.81;
+        const double dt      = 1.0 / 400;
+        const double tiltRad = mrpt::DEG2RAD(10.0);
+
+        ImuInitialCalibrator calibrator;
+        calibrator.parameters.window_seconds   = 1.0;
+        calibrator.parameters.required_samples = 20;
+        calibrator.parameters.max_samples_age  = 10.0;  // ignored in time-window mode
+
+        double t = 0;
+        // 1 s of a 10 deg pitch, then 1.2 s level:
+        for (int i = 0; i < 400; i++, t += dt)
+        {
+            calibrator.add(
+                create_imu_obs(t, {-g * std::sin(tiltRad), 0, g * std::cos(tiltRad)}, {0, 0, 0}));
+        }
+        for (int i = 0; i < 480; i++, t += dt)
+        {
+            calibrator.add(create_imu_obs(t, {0, 0, g}, {0, 0, 0}));
+        }
+
+        const auto calib = calibrator.getCalibration();
+        ASSERT_(calib.has_value());
+        MRPT_ASSERT_NEAR_MSG_(calib->pitch, 0.0, 1e-9, "pitch must forget the pre-window tilt");
+        MRPT_ASSERT_NEAR_MSG_(calib->roll, 0.0, 1e-9, "roll must forget the pre-window tilt");
+
+        std::cout << "Test 18: averaging is restricted to the window OK.\n";
+    }
+
     std::cout << "--- TestImuInitialCalibrator finished OK ---\n";
 }
 

--- a/tests/test-imu-initial-calibrator.cpp
+++ b/tests/test-imu-initial-calibrator.cpp
@@ -908,7 +908,9 @@ void TestImuInitialCalibrator()
             const auto r = calibrator.readiness();
             ASSERT_(!r.ready);  // deferred: the window is not measuring gravity
             ASSERT_(!r.timed_out);
-            ASSERT_(r.span >= 1.0);
+            // span <= window_seconds by construction (windowBegin() is a lower_bound on
+            // newest - window_seconds), so this must be a tolerance, not an equality.
+            ASSERT_(r.span > 1.0 - 2 * dt);
             ASSERT_(r.samples >= 20);
 
             // Keep it dynamic past the timeout: it must initialize anyway.


### PR DESCRIPTION
## What and why

`ImuInitialCalibrator::isReady()` counted samples. That ties the averaging time to the
sensor rate: `required_samples = 400` is 1.0 s at 400 Hz, 2.0 s at 200 Hz and 4.0 s at
100 Hz, and below ~80 Hz those 400 samples never fit inside `max_samples_age = 5.0 s`,
so `isReady()` never returns true and the caller waits forever.

The quantity that actually determines the accuracy of the estimated attitude is the
**duration** of the window, because the error is dominated by platform motion during it,
not by sensor noise. Measured over 13 handheld sequences, the leveling error against
gravity-aligned ground truth grows monotonically with the window: 1.11 deg at 0.1 s,
1.10 at 0.25 s, 1.34 at 0.5 s, 1.50 at 1.0 s, 1.97 at 3.0 s, 2.54 at 10.0 s.

## Changes

- **`Parameters::window_seconds`** (default `0` = off): the buffer is pruned to the window
  (2x it, so it can actually span it), only the samples inside it are averaged, and
  readiness requires the buffer to cover it. `required_samples` degrades to a
  minimum-sample sanity floor.
- **`directionDispersion()`**: RMS angular spread of the buffered accelerometer directions
  about their mean, the same quantity `mola_lidar_odometry` already uses to widen its
  gravity sigma. With `max_direction_dispersion` set, readiness is **deferred** while the
  window is measuring motion rather than gravity; `dispersion_timeout` releases it so a
  platform that is never still still initializes.
- **`readiness()`**: reports samples, span, elapsed, dispersion, whether the timeout fired,
  and a reason string, so a caller can log why it is still waiting.
- Feature macro `MOLA_IMU_PREINT_HAS_INIT_TIME_WINDOW` so dependents can compile against
  older releases.
- A warning comment on `bias_gyro`: it is a plain mean, which on a moving start is real
  rotation rate and not a bias, so it must not be wired into a preintegrator without a
  staticness gate. No behavior change.

## Backwards compatibility

`window_seconds` defaults to `0`, which is exactly the previous sample-count-only rule,
and `max_direction_dispersion` defaults to `0`, i.e. no gate. **An existing user of this
class sees no change at all** unless they opt in. The rate-dependence and the deadlock are
covered by new unit tests so the old behavior is pinned rather than assumed.

## Verification

`tests/test-imu-initial-calibrator.cpp`, all 18 cases pass (16/16 in the package suite):

- **rate independence**: a 1.0 s window becomes ready at 1.0 s (within one sample period)
  at 100, 200 and 400 Hz, with 101 / 201 / 401 samples respectively;
- **the old rule's rate dependence, pinned**: `required_samples = 400` at 100 Hz needs
  4.0 s, and with `max_samples_age = 3.0 s` it is **never** ready (asserted after 20 s of
  simulated data), while the 1.0 s window is ready at 1.01 s on the same stream;
- **minimum-sample floor**: a 10 Hz stream fills the window in time but holds ~11 samples,
  so a floor of 20 correctly blocks it, and the same stream with a floor of 5 is ready;
- **dispersion gate**: a +-3 deg wobble measures as exactly 3 deg of dispersion, defers
  readiness against a 1.5 deg threshold, releases without the timeout once the platform
  becomes still, and is released by the timeout if it never does;
- **windowed averaging**: 1 s of a 10 deg pitch followed by 1.2 s level yields pitch 0.

End-to-end results are in the companion `mola_lidar_odometry` PR.

---
Companion PR: MOLAorg/mola_lidar_odometry (consumes these parameters). That PR needs this
one merged first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration readiness now uses a configurable time window alongside a minimum sample requirement.
  * Added diagnostics showing calibration progress, elapsed time, sample span, and readiness reasons.
  * Added motion detection based on accelerometer-direction dispersion, with configurable timeout handling.

* **Documentation**
  * Clarified calibration timing behavior and that gyro-bias estimates are intended for stationary data.

* **Bug Fixes**
  * Calibration statistics now use only samples from the active averaging window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->