### PR TITLE
Port to mrpt 3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ project(mola_imu_preintegration LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find CMake dependencies:
-find_package(mrpt-obs)
+find_package(mrpt_obs)
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 # Find MOLA packages:
 #find_mola_package(mola-kernel)
@@ -52,9 +53,11 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
-    mrpt::containers
-    mrpt::poses
-    mrpt::obs
+    mrpt::mrpt_containers
+    mrpt::mrpt_poses
+    mrpt::mrpt_obs
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mola_common
 )

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,8 @@
 
 
   <depend>mola_common</depend>
-  <depend>mrpt_libobs</depend>
+  <depend>mrpt_obs</depend>
+  <build_depend>eigen</build_depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ mola_add_test(
   SOURCES test-so3-jacobians.cpp
   LINK_LIBRARIES
     mola::mola_imu_preintegration
+    Eigen3::Eigen
 )
 
 mola_add_test(
@@ -46,6 +47,7 @@ mola_add_test(
   SOURCES test-imu-preintegrator.cpp
   LINK_LIBRARIES
     mola::mola_imu_preintegration
+    Eigen3::Eigen
 )
 
 mola_add_test(
@@ -53,4 +55,5 @@ mola_add_test(
   SOURCES test-map-gravity-estimator.cpp
   LINK_LIBRARIES
     mola::mola_imu_preintegration
+    Eigen3::Eigen
 )


### PR DESCRIPTION
Part of massive MOLA port movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build & Packaging**
  - Updated project dependencies to use the required MRPT container, pose, and observation packages.
  - Added Eigen3 as a required build dependency.
  - Improved compatibility with namespaced MRPT and Eigen3 targets.

- **Tests**
  - Updated selected test builds to link Eigen3 explicitly, ensuring they compile with the required linear algebra dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->